### PR TITLE
Add custom SB properties & gzip compression support

### DIFF
--- a/src/FileHorizon.Application/Common/CompressionHelper.cs
+++ b/src/FileHorizon.Application/Common/CompressionHelper.cs
@@ -1,0 +1,65 @@
+using System.IO.Compression;
+
+namespace FileHorizon.Application.Common;
+
+/// <summary>
+/// Provides gzip compression utilities for message payloads.
+/// </summary>
+public static class CompressionHelper
+{
+    /// <summary>
+    /// Compresses the input data using gzip compression.
+    /// </summary>
+    /// <param name="data">The data to compress.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Compressed data as a byte array.</returns>
+    public static async Task<byte[]> CompressAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+    {
+        if (data.IsEmpty)
+        {
+            return Array.Empty<byte>();
+        }
+
+        using var outputStream = new MemoryStream();
+        await using (var gzipStream = new GZipStream(outputStream, CompressionLevel.Optimal, leaveOpen: true))
+        {
+            await gzipStream.WriteAsync(data, ct).ConfigureAwait(false);
+        }
+        return outputStream.ToArray();
+    }
+
+    /// <summary>
+    /// Decompresses gzip-compressed data.
+    /// </summary>
+    /// <param name="compressedData">The compressed data.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Decompressed data as a byte array.</returns>
+    public static async Task<byte[]> DecompressAsync(ReadOnlyMemory<byte> compressedData, CancellationToken ct = default)
+    {
+        if (compressedData.IsEmpty)
+        {
+            return Array.Empty<byte>();
+        }
+
+        // Optimize memory usage: avoid array copy when the underlying array is accessible
+        MemoryStream inputStream;
+        if (System.Runtime.InteropServices.MemoryMarshal.TryGetArray(compressedData, out var segment))
+        {
+            // Use the underlying array directly without copying
+            inputStream = new MemoryStream(segment.Array!, segment.Offset, segment.Count, writable: false);
+        }
+        else
+        {
+            // Fallback: copy to array (needed for non-array-backed memory)
+            inputStream = new MemoryStream(compressedData.ToArray());
+        }
+
+        using (inputStream)
+        {
+            await using var gzipStream = new GZipStream(inputStream, CompressionMode.Decompress);
+            using var outputStream = new MemoryStream();
+            await gzipStream.CopyToAsync(outputStream, ct).ConfigureAwait(false);
+            return outputStream.ToArray();
+        }
+    }
+}

--- a/src/FileHorizon.Application/Configuration/DestinationsOptions.cs
+++ b/src/FileHorizon.Application/Configuration/DestinationsOptions.cs
@@ -34,6 +34,40 @@ public sealed class ServiceBusDestinationOptions
     public string EntityName { get; set; } = string.Empty; // queue or topic name
     public bool IsTopic { get; set; } = false; // true if EntityName refers to a topic
     public string? ContentType { get; set; } // optional override for message content type, defaults to text/plain
+    public Dictionary<string, string>? ApplicationProperties { get; set; } // optional custom application properties to add to every message sent to this destination
+    
+    /// <summary>
+    /// Enable gzip compression for message bodies sent to this destination. Default is false.
+    /// When enabled, messages are compressed before sending and a 'Content-Encoding: gzip' header is added to application properties.
+    /// </summary>
+    /// <remarks>
+    /// Compression is beneficial for:
+    /// - Large text files (XML, JSON, CSV, log files)
+    /// - Repetitive data that compresses well
+    /// - Reducing bandwidth usage and Service Bus message size limits
+    /// 
+    /// Note: Small messages (< 1KB) may become larger due to gzip overhead.
+    /// Receivers must check the 'Content-Encoding' application property and decompress accordingly.
+    /// 
+    /// Example configuration:
+    /// <code>
+    /// "Destinations": {
+    ///   "ServiceBus": [{
+    ///     "Name": "LargeFilesQueue",
+    ///     "EntityName": "large-files",
+    ///     "EnableGzipCompression": true,
+    ///     "ServiceBusTechnical": {
+    ///       "ConnectionString": "Endpoint=sb://..."
+    ///     }
+    ///   }]
+    /// }
+    /// </code>
+    /// 
+    /// Environment variable:
+    /// Destinations__ServiceBus__0__EnableGzipCompression=true
+    /// </remarks>
+    public bool EnableGzipCompression { get; set; } = false;
+    
     public ServiceBusTechnicalOptions ServiceBusTechnical { get; set; } = new(); // destination specific Service Bus settings (retries, tracing, MI namespace)
 }
 

--- a/src/FileHorizon.Application/Configuration/DestinationsOptionsValidator.cs
+++ b/src/FileHorizon.Application/Configuration/DestinationsOptionsValidator.cs
@@ -56,11 +56,18 @@ public sealed class DestinationsOptionsValidator : IValidateOptions<Destinations
             if (string.IsNullOrWhiteSpace(d.EntityName)) errors.Add($"{prefix}: EntityName must be specified.");
             
             // Validate authentication configuration
-            var hasConnectionString = !string.IsNullOrWhiteSpace(d.ServiceBusTechnical.ConnectionString);
-            var hasNamespace = !string.IsNullOrWhiteSpace(d.ServiceBusTechnical.FullyQualifiedNamespace);
-            if (!hasConnectionString && !hasNamespace)
+            if (d.ServiceBusTechnical is null)
             {
-                errors.Add($"{prefix}: Either ServiceBusTechnical.ConnectionString or ServiceBusTechnical.FullyQualifiedNamespace must be specified.");
+                errors.Add($"{prefix}: ServiceBusTechnical must be configured.");
+            }
+            else
+            {
+                var hasConnectionString = !string.IsNullOrWhiteSpace(d.ServiceBusTechnical.ConnectionString);
+                var hasNamespace = !string.IsNullOrWhiteSpace(d.ServiceBusTechnical.FullyQualifiedNamespace);
+                if (!hasConnectionString && !hasNamespace)
+                {
+                    errors.Add($"{prefix}: Either ServiceBusTechnical.ConnectionString or ServiceBusTechnical.FullyQualifiedNamespace must be specified.");
+                }
             }
             
             // Validate ApplicationProperties for reserved keys

--- a/src/FileHorizon.Application/Configuration/DestinationsOptionsValidator.cs
+++ b/src/FileHorizon.Application/Configuration/DestinationsOptionsValidator.cs
@@ -4,6 +4,14 @@ namespace FileHorizon.Application.Configuration;
 
 public sealed class DestinationsOptionsValidator : IValidateOptions<DestinationsOptions>
 {
+    // Reserved keys that are set by the runtime and cannot be overridden by configuration
+    private static readonly HashSet<string> ReservedApplicationPropertyKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "fh.fileId",
+        "fh.protocol",
+        "Content-Encoding" // Reserved for compression
+    };
+
     public ValidateOptionsResult Validate(string? name, DestinationsOptions options)
     {
         if (options is null) return ValidateOptionsResult.Fail("DestinationsOptions instance is null");
@@ -37,6 +45,39 @@ public sealed class DestinationsOptionsValidator : IValidateOptions<Destinations
                 errors.Add($"{prefix}: PrivateKeyPassphraseSecretRef specified but PrivateKeySecretRef is missing.");
             if (string.IsNullOrWhiteSpace(d.RootPath)) errors.Add($"{prefix}: RootPath must be specified.");
             else if (!Common.PathValidator.IsValidRemotePath(d.RootPath, out var rpErr)) errors.Add($"{prefix}: RootPath invalid: {rpErr}");
+        }
+
+        for (int i = 0; i < options.ServiceBus.Count; i++)
+        {
+            var d = options.ServiceBus[i];
+            var prefix = $"Destinations:ServiceBus[{i}]";
+            if (string.IsNullOrWhiteSpace(d.Name)) errors.Add($"{prefix}: Name must be specified.");
+            else if (!seenNames.Add(d.Name)) errors.Add($"{prefix}: Name '{d.Name}' is duplicated.");
+            if (string.IsNullOrWhiteSpace(d.EntityName)) errors.Add($"{prefix}: EntityName must be specified.");
+            
+            // Validate authentication configuration
+            var hasConnectionString = !string.IsNullOrWhiteSpace(d.ServiceBusTechnical.ConnectionString);
+            var hasNamespace = !string.IsNullOrWhiteSpace(d.ServiceBusTechnical.FullyQualifiedNamespace);
+            if (!hasConnectionString && !hasNamespace)
+            {
+                errors.Add($"{prefix}: Either ServiceBusTechnical.ConnectionString or ServiceBusTechnical.FullyQualifiedNamespace must be specified.");
+            }
+            
+            // Validate ApplicationProperties for reserved keys
+            if (d.ApplicationProperties is not null)
+            {
+                foreach (var key in d.ApplicationProperties.Keys)
+                {
+                    if (ReservedApplicationPropertyKeys.Contains(key))
+                    {
+                        errors.Add($"{prefix}: ApplicationProperty key '{key}' is reserved and cannot be configured.");
+                    }
+                    if (string.IsNullOrWhiteSpace(key))
+                    {
+                        errors.Add($"{prefix}: ApplicationProperty keys cannot be null or whitespace.");
+                    }
+                }
+            }
         }
 
         return errors.Count > 0 ? ValidateOptionsResult.Fail(errors) : ValidateOptionsResult.Success;

--- a/src/FileHorizon.Application/Infrastructure/FileProcessing/FileProcessingOrchestrator.cs
+++ b/src/FileHorizon.Application/Infrastructure/FileProcessing/FileProcessingOrchestrator.cs
@@ -118,12 +118,30 @@ public sealed class FileProcessingOrchestrator(
             }
         }
 
-        string? configuredContentType = _destinations.CurrentValue.ServiceBus
-            .FirstOrDefault(x => string.Equals(x.Name, plan.DestinationName, StringComparison.OrdinalIgnoreCase))?
-            .ContentType;
+        var destinationConfig = _destinations.CurrentValue.ServiceBus
+            .FirstOrDefault(x => string.Equals(x.Name, plan.DestinationName, StringComparison.OrdinalIgnoreCase));
+        
+        string? configuredContentType = destinationConfig?.ContentType;
         var detectedContentType = _fileTypeDetector.Detect(fileEvent.Metadata.SourcePath, sampleBuffer);
         var finalContentType = configuredContentType ?? detectedContentType ?? "application/octet-stream";
         publishActivity?.SetTag("messaging.content_type", finalContentType);
+        
+        // Build application properties: start with configured destination properties, then add runtime properties
+        var applicationProperties = new Dictionary<string, string>();
+        
+        // First: add configured custom properties from destination (if any)
+        if (destinationConfig?.ApplicationProperties is not null)
+        {
+            foreach (var kvp in destinationConfig.ApplicationProperties)
+            {
+                applicationProperties[kvp.Key] = kvp.Value;
+            }
+        }
+        
+        // Second: add runtime properties (these can override configured ones if keys collide)
+        applicationProperties["fh.fileId"] = fileEvent.Id;
+        applicationProperties["fh.protocol"] = fileEvent.Protocol;
+        
         var request = new FilePublishRequest(
             SourcePath: fileEvent.Metadata.SourcePath,
             FileName: Path.GetFileName(fileEvent.Metadata.SourcePath),
@@ -131,11 +149,7 @@ public sealed class FileProcessingOrchestrator(
             ContentType: finalContentType,
             DestinationName: plan.DestinationName,
             IsTopic: plan.IsTopic,
-            ApplicationProperties: new Dictionary<string, string>
-            {
-                ["fh.fileId"] = fileEvent.Id,
-                ["fh.protocol"] = fileEvent.Protocol
-            }
+            ApplicationProperties: applicationProperties
         );
         var publish = await _publisher.PublishAsync(request, ct).ConfigureAwait(false);
         if (publish.IsFailure)

--- a/src/FileHorizon.Application/Infrastructure/Messaging/ServiceBus/AzureServiceBusFileContentPublisher.cs
+++ b/src/FileHorizon.Application/Infrastructure/Messaging/ServiceBus/AzureServiceBusFileContentPublisher.cs
@@ -141,6 +141,7 @@ public sealed class AzureServiceBusFileContentPublisher : IFileContentPublisher,
                 _logger.LogDebug("Compressed {FileName} content from {OriginalSize} to {CompressedSize} bytes",
                     request.FileName, request.Content.Length, compressed.Length);
             }
+            catch (OperationCanceledException) { throw; }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Failed to compress content for {FileName}; sending uncompressed", request.FileName);

--- a/src/FileHorizon.Application/Infrastructure/Messaging/ServiceBus/AzureServiceBusFileContentPublisher.cs
+++ b/src/FileHorizon.Application/Infrastructure/Messaging/ServiceBus/AzureServiceBusFileContentPublisher.cs
@@ -72,21 +72,21 @@ public sealed class AzureServiceBusFileContentPublisher : IFileContentPublisher,
         var validation = ValidateRequest(request);
         if (validation.IsFailure) return validation;
 
-        var (destination, entityName, tech) = ResolveContext(request.DestinationName);
+        var (destinationName, entityName, destination, tech) = ResolveContext(request.DestinationName);
         if (entityName is null)
         {
             return Result.Failure(Error.Messaging.PublishError("Destination entity not resolved"));
         }
-        var client = GetOrCreateClient(destination, tech);
+        var client = GetOrCreateClient(destinationName, tech);
         if (client is null)
         {
             return Result.Failure(Error.Messaging.PublishError("Service Bus client unavailable"));
         }
-        var semaphore = GetSemaphore(destination, tech.MaxConcurrentPublishes);
+        var semaphore = GetSemaphore(destinationName, tech.MaxConcurrentPublishes);
         await semaphore.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            return await SendWithRetryAsync(client, entityName, tech, request, ct).ConfigureAwait(false);
+            return await SendWithRetryAsync(client, entityName, destination, tech, request, ct).ConfigureAwait(false);
         }
         finally
         {
@@ -107,25 +107,47 @@ public sealed class AzureServiceBusFileContentPublisher : IFileContentPublisher,
         return Result.Success();
     }
 
-    private (string destinationName, string? entityName, ServiceBusTechnicalOptions tech) ResolveContext(string logicalDestination)
+    private (string destinationName, string? entityName, ServiceBusDestinationOptions? destination, ServiceBusTechnicalOptions tech) ResolveContext(string logicalDestination)
     {
         var dest = ResolveDestination(logicalDestination);
         if (dest is null)
         {
             // Fallback: create ephemeral default technical options
-            return (logicalDestination, logicalDestination, new ServiceBusTechnicalOptions());
+            return (logicalDestination, logicalDestination, null, new ServiceBusTechnicalOptions());
         }
         var entityName = string.IsNullOrWhiteSpace(dest.EntityName) ? logicalDestination : dest.EntityName;
         var tech = dest.ServiceBusTechnical ?? new ServiceBusTechnicalOptions();
-        return (dest.Name, entityName, tech);
+        return (dest.Name, entityName, dest, tech);
     }
 
-    private async Task<Result> SendWithRetryAsync(ServiceBusClient client, string entityName, ServiceBusTechnicalOptions tech, FilePublishRequest request, CancellationToken ct)
+    private async Task<Result> SendWithRetryAsync(ServiceBusClient client, string entityName, ServiceBusDestinationOptions? destination, ServiceBusTechnicalOptions tech, FilePublishRequest request, CancellationToken ct)
     {
         var attempt = 0;
         var maxRetries = Math.Max(0, tech.PublishRetryCount);
         var baseDelay = TimeSpan.FromMilliseconds(Math.Max(0, tech.PublishRetryBaseDelayMs));
         var maxDelay = TimeSpan.FromMilliseconds(Math.Max(tech.PublishRetryBaseDelayMs, tech.PublishRetryMaxDelayMs));
+
+        // Apply compression if enabled
+        ReadOnlyMemory<byte> messageContent = request.Content;
+        var isCompressed = false;
+        var enableCompression = destination?.EnableGzipCompression ?? false;
+        if (enableCompression && !request.Content.IsEmpty)
+        {
+            try
+            {
+                var compressed = await CompressionHelper.CompressAsync(request.Content, ct).ConfigureAwait(false);
+                messageContent = compressed;
+                isCompressed = true;
+                _logger.LogDebug("Compressed {FileName} content from {OriginalSize} to {CompressedSize} bytes",
+                    request.FileName, request.Content.Length, compressed.Length);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to compress content for {FileName}; sending uncompressed", request.FileName);
+                // Continue with uncompressed content
+            }
+        }
+
         while (true)
         {
             ct.ThrowIfCancellationRequested();
@@ -133,7 +155,7 @@ public sealed class AzureServiceBusFileContentPublisher : IFileContentPublisher,
             {
                 _publishAttempts.Add(1, new KeyValuePair<string, object?>("destination", request.DestinationName));
                 var sender = client.CreateSender(entityName);
-                var message = CreateMessage(request.Content, request);
+                var message = CreateMessage(messageContent, request, isCompressed);
                 await sender.SendMessageAsync(message, ct).ConfigureAwait(false);
                 _publishSuccesses.Add(1, new KeyValuePair<string, object?>("destination", request.DestinationName));
                 LogPublishSuccess(request.FileName, request.DestinationName, entityName, attempt);
@@ -226,7 +248,7 @@ public sealed class AzureServiceBusFileContentPublisher : IFileContentPublisher,
         return _destinationConcurrency.GetOrAdd(destinationName, _ => new SemaphoreSlim(effective, effective));
     }
 
-    private static ServiceBusMessage CreateMessage(ReadOnlyMemory<byte> content, FilePublishRequest request)
+    private static ServiceBusMessage CreateMessage(ReadOnlyMemory<byte> content, FilePublishRequest request, bool isCompressed)
     {
         var message = new ServiceBusMessage(content);
         if (!string.IsNullOrWhiteSpace(request.ContentType))
@@ -240,6 +262,13 @@ public sealed class AzureServiceBusFileContentPublisher : IFileContentPublisher,
                 message.ApplicationProperties[kvp.Key] = kvp.Value;
             }
         }
+        
+        // Add compression indicator if content is compressed
+        if (isCompressed)
+        {
+            message.ApplicationProperties["Content-Encoding"] = "gzip";
+        }
+        
         message.Subject = request.FileName;
         return message;
     }

--- a/test/FileHorizon.Application.Tests/CompressionHelperTests.cs
+++ b/test/FileHorizon.Application.Tests/CompressionHelperTests.cs
@@ -1,0 +1,149 @@
+using System.Text;
+using FileHorizon.Application.Common;
+using Xunit;
+
+namespace FileHorizon.Application.Tests;
+
+public class CompressionHelperTests
+{
+    [Fact]
+    public async Task CompressAsync_WithValidData_ReturnsCompressedData()
+    {
+        // Use longer text to ensure compression actually reduces size (gzip has overhead for small data)
+        var originalData = Encoding.UTF8.GetBytes(string.Join("", Enumerable.Repeat("This is test data that should be compressed using gzip compression algorithm. ", 20)));
+        
+        var compressed = await CompressionHelper.CompressAsync(originalData);
+        
+        Assert.NotNull(compressed);
+        Assert.NotEmpty(compressed);
+        // Compressed data should be smaller for text with repetition
+        Assert.True(compressed.Length < originalData.Length, 
+            $"Compressed size ({compressed.Length}) should be less than original size ({originalData.Length})");
+    }
+
+    [Fact]
+    public async Task CompressAsync_WithEmptyData_ReturnsEmpty()
+    {
+        var emptyData = Array.Empty<byte>();
+        
+        var compressed = await CompressionHelper.CompressAsync(emptyData);
+        
+        Assert.NotNull(compressed);
+        Assert.Empty(compressed);
+    }
+
+    [Fact]
+    public async Task DecompressAsync_WithValidCompressedData_ReturnsOriginalData()
+    {
+        var originalData = Encoding.UTF8.GetBytes("This is test data for compression and decompression test.");
+        var compressed = await CompressionHelper.CompressAsync(originalData);
+        
+        var decompressed = await CompressionHelper.DecompressAsync(compressed);
+        
+        Assert.Equal(originalData, decompressed);
+    }
+
+    [Fact]
+    public async Task DecompressAsync_WithEmptyData_ReturnsEmpty()
+    {
+        var emptyData = Array.Empty<byte>();
+        
+        var decompressed = await CompressionHelper.DecompressAsync(emptyData);
+        
+        Assert.NotNull(decompressed);
+        Assert.Empty(decompressed);
+    }
+
+    [Fact]
+    public async Task CompressAndDecompress_RoundTrip_PreservesOriginalData()
+    {
+        var testCases = new[]
+        {
+            "Simple text",
+            "Text with special characters: !@#$%^&*()",
+            "Repeated text " + string.Join("", Enumerable.Repeat("repeat ", 100)),
+            "Unicode text: ??????? ??",
+            string.Join("\n", Enumerable.Range(1, 100).Select(i => $"Line {i} with some content"))
+        };
+
+        foreach (var testCase in testCases)
+        {
+            var originalData = Encoding.UTF8.GetBytes(testCase);
+            
+            var compressed = await CompressionHelper.CompressAsync(originalData);
+            var decompressed = await CompressionHelper.DecompressAsync(compressed);
+            var resultText = Encoding.UTF8.GetString(decompressed);
+            
+            Assert.Equal(testCase, resultText);
+        }
+    }
+
+    [Fact]
+    public async Task CompressAsync_CancellationRequested_ThrowsOperationCanceledException()
+    {
+        var largeData = Encoding.UTF8.GetBytes(string.Join("", Enumerable.Repeat("test data ", 10000)));
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        
+        // TaskCanceledException inherits from OperationCanceledException, so we accept both
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await CompressionHelper.CompressAsync(largeData, cts.Token));
+        
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public async Task CompressAsync_WithRandomBinaryData_ProducesValidOutput()
+    {
+        // Random binary data typically doesn't compress well, may even grow
+        var random = new Random(42); // Fixed seed for reproducibility
+        var binaryData = new byte[1024];
+        random.NextBytes(binaryData);
+        
+        var compressed = await CompressionHelper.CompressAsync(binaryData);
+        
+        Assert.NotNull(compressed);
+        Assert.NotEmpty(compressed);
+        
+        // Verify it can be decompressed back to original
+        var decompressed = await CompressionHelper.DecompressAsync(compressed);
+        Assert.Equal(binaryData, decompressed);
+    }
+
+    [Fact]
+    public async Task CompressAsync_WithAlreadyCompressedData_StillWorks()
+    {
+        // Compress data twice (though this would be inefficient in practice)
+        var originalData = Encoding.UTF8.GetBytes("Test data for double compression");
+        var firstCompression = await CompressionHelper.CompressAsync(originalData);
+        
+        // Compress the already-compressed data
+        var secondCompression = await CompressionHelper.CompressAsync(firstCompression);
+        
+        Assert.NotNull(secondCompression);
+        Assert.NotEmpty(secondCompression);
+        // Second compression typically makes it larger (already compressed data doesn't compress well)
+        Assert.True(secondCompression.Length >= firstCompression.Length);
+        
+        // Verify double decompression works
+        var firstDecompression = await CompressionHelper.DecompressAsync(secondCompression);
+        var secondDecompression = await CompressionHelper.DecompressAsync(firstDecompression);
+        Assert.Equal(originalData, secondDecompression);
+    }
+
+    [Fact]
+    public async Task CompressAsync_WithSmallData_MayIncreaseSizeButStillValid()
+    {
+        // Very small data often becomes larger due to gzip header overhead
+        var smallData = Encoding.UTF8.GetBytes("Hi");
+        
+        var compressed = await CompressionHelper.CompressAsync(smallData);
+        
+        Assert.NotNull(compressed);
+        Assert.NotEmpty(compressed);
+        // Gzip header is ~18 bytes, so very small data will be larger when compressed
+        // But it should still decompress correctly
+        var decompressed = await CompressionHelper.DecompressAsync(compressed);
+        Assert.Equal(smallData, decompressed);
+    }
+}

--- a/test/FileHorizon.Application.Tests/DestinationsOptionsValidatorTests.cs
+++ b/test/FileHorizon.Application.Tests/DestinationsOptionsValidatorTests.cs
@@ -1,0 +1,258 @@
+using FileHorizon.Application.Configuration;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace FileHorizon.Application.Tests;
+
+public class DestinationsOptionsValidatorTests
+{
+    private readonly DestinationsOptionsValidator _validator = new();
+
+    [Fact]
+    public void Validate_ServiceBusDestination_WithValidConfig_Succeeds()
+    {
+        var options = new DestinationsOptions
+        {
+            ServiceBus =
+            [
+                new ServiceBusDestinationOptions
+                {
+                    Name = "TestQueue",
+                    EntityName = "test-queue",
+                    IsTopic = false,
+                    ContentType = "application/json",
+                    ApplicationProperties = new Dictionary<string, string>
+                    {
+                        ["correlationId"] = "12345",
+                        ["customLabel"] = "test-label"
+                    },
+                    ServiceBusTechnical = new ServiceBusTechnicalOptions
+                    {
+                        ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=Test;SharedAccessKey=abc123="
+                    }
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_ServiceBusDestination_WithManagedIdentity_Succeeds()
+    {
+        var options = new DestinationsOptions
+        {
+            ServiceBus =
+            [
+                new ServiceBusDestinationOptions
+                {
+                    Name = "TestQueue",
+                    EntityName = "test-queue",
+                    ServiceBusTechnical = new ServiceBusTechnicalOptions
+                    {
+                        FullyQualifiedNamespace = "test-namespace.servicebus.windows.net"
+                    }
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_ServiceBusDestination_WithoutAuthenticationMethod_Fails()
+    {
+        var options = new DestinationsOptions
+        {
+            ServiceBus =
+            [
+                new ServiceBusDestinationOptions
+                {
+                    Name = "TestQueue",
+                    EntityName = "test-queue",
+                    ServiceBusTechnical = new ServiceBusTechnicalOptions()
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("ConnectionString", result.FailureMessage);
+        Assert.Contains("FullyQualifiedNamespace", result.FailureMessage);
+        Assert.Contains("must be specified", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_ServiceBusDestination_WithReservedKey_Fails()
+    {
+        var options = new DestinationsOptions
+        {
+            ServiceBus =
+            [
+                new ServiceBusDestinationOptions
+                {
+                    Name = "TestQueue",
+                    EntityName = "test-queue",
+                    ApplicationProperties = new Dictionary<string, string>
+                    {
+                        ["fh.fileId"] = "override-attempt"
+                    },
+                    ServiceBusTechnical = new ServiceBusTechnicalOptions
+                    {
+                        ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;"
+                    }
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("fh.fileId", result.FailureMessage);
+        Assert.Contains("reserved", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_ServiceBusDestination_WithContentEncodingKey_Fails()
+    {
+        var options = new DestinationsOptions
+        {
+            ServiceBus =
+            [
+                new ServiceBusDestinationOptions
+                {
+                    Name = "TestQueue",
+                    EntityName = "test-queue",
+                    ApplicationProperties = new Dictionary<string, string>
+                    {
+                        ["Content-Encoding"] = "custom"
+                    },
+                    ServiceBusTechnical = new ServiceBusTechnicalOptions
+                    {
+                        ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;"
+                    }
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("Content-Encoding", result.FailureMessage);
+        Assert.Contains("reserved", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_ServiceBusDestination_MissingName_Fails()
+    {
+        var options = new DestinationsOptions
+        {
+            ServiceBus =
+            [
+                new ServiceBusDestinationOptions
+                {
+                    Name = "",
+                    EntityName = "test-queue",
+                    ServiceBusTechnical = new ServiceBusTechnicalOptions
+                    {
+                        ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;"
+                    }
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("Name must be specified", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_ServiceBusDestination_MissingEntityName_Fails()
+    {
+        var options = new DestinationsOptions
+        {
+            ServiceBus =
+            [
+                new ServiceBusDestinationOptions
+                {
+                    Name = "TestQueue",
+                    EntityName = "",
+                    ServiceBusTechnical = new ServiceBusTechnicalOptions
+                    {
+                        ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;"
+                    }
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("EntityName must be specified", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_ServiceBusDestination_DuplicateName_Fails()
+    {
+        var options = new DestinationsOptions
+        {
+            ServiceBus =
+            [
+                new ServiceBusDestinationOptions
+                {
+                    Name = "TestQueue",
+                    EntityName = "queue1",
+                    ServiceBusTechnical = new ServiceBusTechnicalOptions
+                    {
+                        ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;"
+                    }
+                },
+                new ServiceBusDestinationOptions
+                {
+                    Name = "TestQueue",
+                    EntityName = "queue2",
+                    ServiceBusTechnical = new ServiceBusTechnicalOptions
+                    {
+                        ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;"
+                    }
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("duplicated", result.FailureMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_ServiceBusDestination_NoApplicationProperties_Succeeds()
+    {
+        var options = new DestinationsOptions
+        {
+            ServiceBus =
+            [
+                new ServiceBusDestinationOptions
+                {
+                    Name = "TestQueue",
+                    EntityName = "test-queue",
+                    ApplicationProperties = null,
+                    ServiceBusTechnical = new ServiceBusTechnicalOptions
+                    {
+                        ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;"
+                    }
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.True(result.Succeeded);
+    }
+}

--- a/test/FileHorizon.Application.Tests/DestinationsOptionsValidatorTests.cs
+++ b/test/FileHorizon.Application.Tests/DestinationsOptionsValidatorTests.cs
@@ -232,6 +232,28 @@ public class DestinationsOptionsValidatorTests
     }
 
     [Fact]
+    public void Validate_ServiceBusDestination_NullServiceBusTechnical_Fails()
+    {
+        var options = new DestinationsOptions
+        {
+            ServiceBus =
+            [
+                new ServiceBusDestinationOptions
+                {
+                    Name = "TestQueue",
+                    EntityName = "test-queue",
+                    ServiceBusTechnical = null!
+                }
+            ]
+        };
+
+        var result = _validator.Validate(null, options);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("ServiceBusTechnical must be configured", result.FailureMessage);
+    }
+
+    [Fact]
     public void Validate_ServiceBusDestination_NoApplicationProperties_Succeeds()
     {
         var options = new DestinationsOptions

--- a/test/FileHorizon.Application.Tests/ServiceBusCustomPropertiesTests.cs
+++ b/test/FileHorizon.Application.Tests/ServiceBusCustomPropertiesTests.cs
@@ -1,0 +1,251 @@
+using System.Text;
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Common;
+using FileHorizon.Application.Configuration;
+using FileHorizon.Application.Infrastructure.FileProcessing;
+using FileHorizon.Application.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace FileHorizon.Application.Tests;
+
+public class ServiceBusCustomPropertiesTests
+{
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+        where T : class, new()
+    {
+        private readonly T _value = value;
+        public T CurrentValue => _value;
+        public T Get(string? name) => _value;
+        public IDisposable OnChange(Action<T, string?> listener) => new NoopDisposable();
+        private sealed class NoopDisposable : IDisposable { public void Dispose() { } }
+    }
+
+    private sealed class CapturingPublisher : IFileContentPublisher
+    {
+        public FilePublishRequest? LastRequest { get; private set; }
+        public bool WasCalled { get; private set; }
+
+        public Task<Result> PublishAsync(FilePublishRequest request, CancellationToken ct)
+        {
+            WasCalled = true;
+            LastRequest = request;
+            return Task.FromResult(Result.Success());
+        }
+    }
+
+    [Fact]
+    public async Task Orchestrator_MergesConfiguredApplicationProperties_WithRuntimeProperties()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid():N}.txt");
+        var content = "test content for custom properties";
+        await File.WriteAllTextAsync(tempFile, content);
+
+        try
+        {
+            var publisher = new CapturingPublisher();
+            var destinations = new DestinationsOptions
+            {
+                ServiceBus =
+                [
+                    new ServiceBusDestinationOptions
+                    {
+                        Name = "TestQueue",
+                        EntityName = "test-queue",
+                        IsTopic = false,
+                        ContentType = "text/plain",
+                        ApplicationProperties = new Dictionary<string, string>
+                        {
+                            ["correlationId"] = "test-correlation-123",
+                            ["customLabel"] = "integration-test",
+                            ["environment"] = "dev"
+                        }
+                    }
+                ]
+            };
+
+            var routing = new RoutingOptions
+            {
+                Rules =
+                [
+                    new RoutingRuleOptions
+                    {
+                        Name = "TestRule",
+                        Protocol = "local",
+                        PathGlob = "**/*.txt",
+                        Destinations = ["TestQueue"]
+                    }
+                ]
+            };
+
+            var router = new Infrastructure.Processing.SimpleFileRouter(
+                routingOptions: new StaticOptionsMonitor<RoutingOptions>(routing),
+                destinationsOptions: new StaticOptionsMonitor<DestinationsOptions>(destinations),
+                logger: NullLogger<Infrastructure.Processing.SimpleFileRouter>.Instance
+            );
+
+            var readers = new List<IFileContentReader>
+            {
+                new Infrastructure.Processing.LocalFileContentReader(NullLogger<Infrastructure.Processing.LocalFileContentReader>.Instance)
+            };
+
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+            var orchestrator = new FileProcessingOrchestrator(
+                router: router,
+                readers: readers,
+                sinks: new List<IFileSink>(),
+                destinations: new StaticOptionsMonitor<DestinationsOptions>(destinations),
+                idempotencyOptions: new StaticOptionsMonitor<IdempotencyOptions>(new IdempotencyOptions { Enabled = false }),
+                remoteSources: new StaticOptionsMonitor<RemoteFileSourcesOptions>(new RemoteFileSourcesOptions()),
+                idempotencyStore: new Infrastructure.Idempotency.InMemoryIdempotencyStore(),
+                sftpFactory: new Infrastructure.Remote.SshNetSftpClientFactory(NullLogger<Infrastructure.Remote.SshNetSftpClientFactory>.Instance),
+                secretResolver: new Infrastructure.Secrets.InMemorySecretResolver(configuration, NullLogger<Infrastructure.Secrets.InMemorySecretResolver>.Instance),
+                sftpClientLogger: NullLogger<Infrastructure.Remote.SftpRemoteFileClient>.Instance,
+                ftpClientLogger: NullLogger<Infrastructure.Remote.FtpRemoteFileClient>.Instance,
+                publisher: publisher,
+                fileTypeDetector: new Infrastructure.Processing.ExtensionFileTypeDetector(),
+                logger: NullLogger<FileProcessingOrchestrator>.Instance
+            );
+
+            var fileEvent = new FileEvent(
+                Id: Guid.NewGuid().ToString("N"),
+                Metadata: new FileMetadata(tempFile, new FileInfo(tempFile).Length, DateTimeOffset.UtcNow, "none", null),
+                DiscoveredAtUtc: DateTimeOffset.UtcNow,
+                Protocol: "local",
+                DestinationPath: string.Empty,
+                DeleteAfterTransfer: false
+            );
+
+            // Act
+            var result = await orchestrator.ProcessAsync(fileEvent, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.True(publisher.WasCalled);
+            Assert.NotNull(publisher.LastRequest);
+            Assert.NotNull(publisher.LastRequest.ApplicationProperties);
+
+            // Verify configured properties are present
+            Assert.Equal("test-correlation-123", publisher.LastRequest.ApplicationProperties["correlationId"]);
+            Assert.Equal("integration-test", publisher.LastRequest.ApplicationProperties["customLabel"]);
+            Assert.Equal("dev", publisher.LastRequest.ApplicationProperties["environment"]);
+
+            // Verify runtime properties are also present
+            Assert.Equal(fileEvent.Id, publisher.LastRequest.ApplicationProperties["fh.fileId"]);
+            Assert.Equal("local", publisher.LastRequest.ApplicationProperties["fh.protocol"]);
+
+            // Verify there are 5 total properties (3 configured + 2 runtime)
+            Assert.Equal(5, publisher.LastRequest.ApplicationProperties.Count);
+        }
+        finally
+        {
+            // Cleanup
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Orchestrator_WithNoConfiguredProperties_OnlyAddsRuntimeProperties()
+    {
+        // Arrange
+        var tempFile = Path.Combine(Path.GetTempPath(), $"test-{Guid.NewGuid():N}.txt");
+        await File.WriteAllTextAsync(tempFile, "test");
+
+        try
+        {
+            var publisher = new CapturingPublisher();
+            var destinations = new DestinationsOptions
+            {
+                ServiceBus =
+                [
+                    new ServiceBusDestinationOptions
+                    {
+                        Name = "TestQueue",
+                        EntityName = "test-queue",
+                        ApplicationProperties = null // No configured properties
+                    }
+                ]
+            };
+
+            var routing = new RoutingOptions
+            {
+                Rules =
+                [
+                    new RoutingRuleOptions
+                    {
+                        Name = "TestRule",
+                        Protocol = "local",
+                        PathGlob = "**/*.txt",
+                        Destinations = ["TestQueue"]
+                    }
+                ]
+            };
+
+            var router = new Infrastructure.Processing.SimpleFileRouter(
+                routingOptions: new StaticOptionsMonitor<RoutingOptions>(routing),
+                destinationsOptions: new StaticOptionsMonitor<DestinationsOptions>(destinations),
+                logger: NullLogger<Infrastructure.Processing.SimpleFileRouter>.Instance
+            );
+
+            var readers = new List<IFileContentReader>
+            {
+                new Infrastructure.Processing.LocalFileContentReader(NullLogger<Infrastructure.Processing.LocalFileContentReader>.Instance)
+            };
+
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+            var orchestrator = new FileProcessingOrchestrator(
+                router: router,
+                readers: readers,
+                sinks: new List<IFileSink>(),
+                destinations: new StaticOptionsMonitor<DestinationsOptions>(destinations),
+                idempotencyOptions: new StaticOptionsMonitor<IdempotencyOptions>(new IdempotencyOptions { Enabled = false }),
+                remoteSources: new StaticOptionsMonitor<RemoteFileSourcesOptions>(new RemoteFileSourcesOptions()),
+                idempotencyStore: new Infrastructure.Idempotency.InMemoryIdempotencyStore(),
+                sftpFactory: new Infrastructure.Remote.SshNetSftpClientFactory(NullLogger<Infrastructure.Remote.SshNetSftpClientFactory>.Instance),
+                secretResolver: new Infrastructure.Secrets.InMemorySecretResolver(configuration, NullLogger<Infrastructure.Secrets.InMemorySecretResolver>.Instance),
+                sftpClientLogger: NullLogger<Infrastructure.Remote.SftpRemoteFileClient>.Instance,
+                ftpClientLogger: NullLogger<Infrastructure.Remote.FtpRemoteFileClient>.Instance,
+                publisher: publisher,
+                fileTypeDetector: new Infrastructure.Processing.ExtensionFileTypeDetector(),
+                logger: NullLogger<FileProcessingOrchestrator>.Instance
+            );
+
+            var fileEvent = new FileEvent(
+                Id: Guid.NewGuid().ToString("N"),
+                Metadata: new FileMetadata(tempFile, new FileInfo(tempFile).Length, DateTimeOffset.UtcNow, "none", null),
+                DiscoveredAtUtc: DateTimeOffset.UtcNow,
+                Protocol: "local",
+                DestinationPath: string.Empty,
+                DeleteAfterTransfer: false
+            );
+
+            // Act
+            var result = await orchestrator.ProcessAsync(fileEvent, CancellationToken.None);
+
+            // Assert
+            Assert.True(result.IsSuccess);
+            Assert.True(publisher.WasCalled);
+            Assert.NotNull(publisher.LastRequest);
+            Assert.NotNull(publisher.LastRequest.ApplicationProperties);
+
+            // Only runtime properties should be present
+            Assert.Equal(2, publisher.LastRequest.ApplicationProperties.Count);
+            Assert.Equal(fileEvent.Id, publisher.LastRequest.ApplicationProperties["fh.fileId"]);
+            Assert.Equal("local", publisher.LastRequest.ApplicationProperties["fh.protocol"]);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+}

--- a/test/FileHorizon.Application.Tests/ServiceBusFileContentPublisherTests.cs
+++ b/test/FileHorizon.Application.Tests/ServiceBusFileContentPublisherTests.cs
@@ -12,7 +12,7 @@ namespace FileHorizon.Application.Tests;
 
 public class ServiceBusFileContentPublisherTests
 {
-    private AzureServiceBusFileContentPublisher CreatePublisher(string connection = "Endpoint=sb://localhost/;SharedAccessKeyName=Root;SharedAccessKey=Fake=")
+    private AzureServiceBusFileContentPublisher CreatePublisher(string connection = "Endpoint=sb://localhost/;SharedAccessKeyName=Root;SharedAccessKey=Fake=", bool enableCompression = false)
     {
         // Provide destinations options with a sample service bus destination including connection string so mapping can be exercised
         var dests = Substitute.For<IOptionsMonitor<DestinationsOptions>>();
@@ -24,6 +24,7 @@ public class ServiceBusFileContentPublisherTests
                     Name = "queue1",
                     EntityName = "queue1",
                     IsTopic = false,
+                    EnableGzipCompression = enableCompression,
                     ServiceBusTechnical = new ServiceBusTechnicalOptions { PublishRetryCount = 0, ConnectionString = connection }
                 }
             ],
@@ -62,5 +63,15 @@ public class ServiceBusFileContentPublisherTests
         var result = await publisher.PublishAsync(req, CancellationToken.None);
         Assert.True(result.IsFailure);
         Assert.Equal("Messaging.ContentEmpty", result.Error.Code);
+    }
+
+    [Fact(Skip = "Requires live Service Bus or refactoring for mock client")]
+    public async Task Compression_Enabled_Publishes_Compressed_Content()
+    {
+        var publisher = CreatePublisher(enableCompression: true);
+        var content = Encoding.UTF8.GetBytes("hello world with lots of repeating text to compress well compress compress");
+        var req = new FilePublishRequest("/tmp", "test.txt", content, "text/plain", "queue1", false);
+        var result = await publisher.PublishAsync(req, CancellationToken.None);
+        Assert.True(result.IsSuccess);
     }
 }


### PR DESCRIPTION
Enable configuration of custom Service Bus application properties per destination, with validation to prevent reserved key overrides. Add optional gzip compression for message bodies, automatically setting Content-Encoding. Update orchestrator and publisher logic to merge properties and handle compression. Include new unit and integration tests for validation, property merging, and compression utilities.