### PR TITLE
fix(core): start fresh trace per file to prevent shared Diagnostic-Id

### DIFF
--- a/src/FileHorizon.Application/Core/FileProcessingService.cs
+++ b/src/FileHorizon.Application/Core/FileProcessingService.cs
@@ -23,7 +23,19 @@ public sealed class FileProcessingService(IFileProcessor fileProcessor, ILogger<
         _logger.LogDebug("Processing file event {FileId} protocol={Protocol} path={Path}", fileEvent.Id, fileEvent.Protocol, fileEvent.Metadata.SourcePath);
 
         var start = Stopwatch.GetTimestamp();
-        using var activity = TelemetryInstrumentation.ActivitySource.StartActivity("file.process", ActivityKind.Internal);
+
+        // Start a fresh root trace per file so that child spans (e.g. servicebus.publish)
+        // carry a unique trace-id. Without an explicit parent context, StartActivity inherits
+        // Activity.Current — which may be the long-lived pipeline.lifetime activity started in
+        // CompositeHostedService.StartAsync. That causes every file in a batch to share the
+        // same trace-id, making Service Bus Diagnostic-Id identical across files and collapsing
+        // independent Logic App runs into a single chain (issue #22).
+        var freshRoot = new ActivityContext(
+            ActivityTraceId.CreateRandom(),
+            ActivitySpanId.CreateRandom(),
+            ActivityTraceFlags.Recorded,
+            isRemote: true);
+        using var activity = TelemetryInstrumentation.ActivitySource.StartActivity("file.process", ActivityKind.Internal, freshRoot);
         activity?.SetTag("file.id", fileEvent.Id);
         activity?.SetTag("file.protocol", fileEvent.Protocol);
         activity?.SetTag("file.source_path", fileEvent.Metadata.SourcePath);

--- a/src/FileHorizon.Application/Core/FileProcessingService.cs
+++ b/src/FileHorizon.Application/Core/FileProcessingService.cs
@@ -33,8 +33,7 @@ public sealed class FileProcessingService(IFileProcessor fileProcessor, ILogger<
         var freshRoot = new ActivityContext(
             ActivityTraceId.CreateRandom(),
             ActivitySpanId.CreateRandom(),
-            ActivityTraceFlags.Recorded,
-            isRemote: true);
+            ActivityTraceFlags.Recorded);
         using var activity = TelemetryInstrumentation.ActivitySource.StartActivity("file.process", ActivityKind.Internal, freshRoot);
         activity?.SetTag("file.id", fileEvent.Id);
         activity?.SetTag("file.protocol", fileEvent.Protocol);

--- a/test/FileHorizon.Application.Tests/Telemetry/FileProcessingServiceTelemetryTests.cs
+++ b/test/FileHorizon.Application.Tests/Telemetry/FileProcessingServiceTelemetryTests.cs
@@ -76,4 +76,41 @@ public sealed class FileProcessingServiceTelemetryTests
         Assert.Equal(1, telemetry.FailureCount);
         Assert.DoesNotContain(telemetry.DurationsMs, d => d <= 0);
     }
+
+    /// <summary>
+    /// Regression test for issue #22: files processed in the same batch must not share a trace-id.
+    /// The pipeline.lifetime activity is alive when background services run, so without an explicit
+    /// fresh root context each file.process span would inherit the same trace-id from that ambient
+    /// parent, causing Service Bus Diagnostic-Id to collide across files.
+    /// </summary>
+    [Fact]
+    public async Task TwoFilesInSameBatch_HaveDifferentTraceIds()
+    {
+        var telemetry = new FakeTelemetry();
+        var svc = new FileProcessingService(new SuccessProcessor(), NullLogger<FileProcessingService>.Instance, telemetry);
+
+        var traceIds = new List<ActivityTraceId>();
+
+        using var activityListener = new ActivityListener
+        {
+            ShouldListenTo = s => s.Name == TelemetryInstrumentation.ActivitySourceName,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = a =>
+            {
+                if (a.OperationName == "file.process")
+                    traceIds.Add(a.TraceId);
+            },
+            ActivityStopped = _ => { }
+        };
+        ActivitySource.AddActivityListener(activityListener);
+
+        // Simulate a batch-level ambient activity (pipeline.lifetime equivalent)
+        using var batchActivity = new ActivitySource("test.batch").StartActivity("batch");
+
+        await svc.HandleAsync(CreateEvent("fileA"), CancellationToken.None);
+        await svc.HandleAsync(CreateEvent("fileB"), CancellationToken.None);
+
+        Assert.Equal(2, traceIds.Count);
+        Assert.NotEqual(traceIds[0], traceIds[1]);
+    }
 }

--- a/test/FileHorizon.Application.Tests/Telemetry/FileProcessingServiceTelemetryTests.cs
+++ b/test/FileHorizon.Application.Tests/Telemetry/FileProcessingServiceTelemetryTests.cs
@@ -105,7 +105,9 @@ public sealed class FileProcessingServiceTelemetryTests
         ActivitySource.AddActivityListener(activityListener);
 
         // Simulate a batch-level ambient activity (pipeline.lifetime equivalent)
-        using var batchActivity = new ActivitySource("test.batch").StartActivity("batch");
+        using var batchActivity = new Activity("pipeline.lifetime");
+        batchActivity.SetIdFormat(ActivityIdFormat.W3C);
+        batchActivity.Start();
 
         await svc.HandleAsync(CreateEvent("fileA"), CancellationToken.None);
         await svc.HandleAsync(CreateEvent("fileB"), CancellationToken.None);


### PR DESCRIPTION
## Problem (fixes #22)

When multiple files are processed in the same dispatch window, all outgoing Service Bus messages share the same `Diagnostic-Id` (`traceparent`), varying only the span-id. Downstream systems (e.g. Logic Apps) derive `clientTrackingId` from the **trace-id** portion, so every file in a batch collapses into a single chain instead of appearing as independent runs.

### Root cause

`CompositeHostedService.StartAsync` creates the long-lived `pipeline.lifetime` activity **before** starting the background services. .NET's `ExecutionContext` flows the ambient `Activity.Current` into `BackgroundService.ExecuteAsync`. Every subsequent `file.process` span therefore becomes a child of `pipeline.lifetime` and inherits its trace-id — meaning every file processed during the application's lifetime shares the same trace-id.

## Fix

In `FileProcessingService.HandleAsync`, pass a freshly generated `ActivityContext` to `StartActivity("file.process")`, seeding a new `TraceId` per file. All child spans (`file.orchestrate` → `servicebus.publish`) automatically inherit this fresh trace-id, so each outgoing Service Bus message carries a distinct `Diagnostic-Id`.

```csharp
var freshRoot = new ActivityContext(
    ActivityTraceId.CreateRandom(),
    ActivitySpanId.CreateRandom(),
    ActivityTraceFlags.Recorded,
    isRemote: true);
using var activity = TelemetryInstrumentation.ActivitySource.StartActivity("file.process", ActivityKind.Internal, freshRoot);
```

## Test

Added `TwoFilesInSameBatch_HaveDifferentTraceIds` in `FileProcessingServiceTelemetryTests`:
- Installs a batch-level ambient activity (simulating `pipeline.lifetime`)
- Processes two files sequentially
- Asserts that their `file.process` spans carry **different** `TraceId`s

All 105 tests pass (3 skipped as before).