### PR TITLE
feat(telemetry): complete OTLP wiring for logs, protocol and insecure gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,9 +667,11 @@ If enabled (default), metrics are exposed at `GET /metrics` using the Prometheus
 | `EnableLogging`         | true                   | Route structured logs through OTEL exporter                    |
 | `EnablePrometheus`      | true                   | Expose `/metrics` endpoint                                     |
 | `EnableOtlpExporter`    | false                  | Enable OTLP exporter for traces/metrics/logs                   |
-| `OtlpEndpoint`          | null                   | OTLP/gRPC or HTTP endpoint (e.g. `http://otel-collector:4317`) |
+| `OtlpEndpoint`          | null                   | OTLP endpoint (e.g. `http://otel-collector:4317` for gRPC)     |
+| `OtlpProtocol`          | Grpc                   | Wire protocol: `Grpc` (port 4317) or `HttpProtobuf` (port 4318)|
 | `OtlpHeaders`           | null                   | Additional OTLP headers (key=value;key2=value2)                |
-| `OtlpInsecure`          | false                  | Allow insecure (no TLS) if collector enforces it               |
+| `OtlpInsecure`          | false                  | Allow gRPC over plaintext `http://` (enables HTTP/2 cleartext) |
+| `TracesSampleRatio`     | null                   | null = sample all; `0..1` = parent-based ratio sampler         |
 | `ServiceName`           | FileHorizon            | Override service.name resource attribute                       |
 | `ServiceVersion`        | Assembly version       | Override service.version                                       |
 | `DeploymentEnvironment` | ASPNETCORE_ENVIRONMENT | Adds `deployment.environment` attribute                        |
@@ -691,11 +693,27 @@ Telemetry__EnableOtlpExporter=true
 Telemetry__OtlpEndpoint=http://otel-collector:4317
 ```
 
-If headers are required (HTTP/Protobuf variant):
+For the HTTP/Protobuf variant (collector listens on 4318), select the protocol and adjust the endpoint:
+
+```
+Telemetry__EnableOtlpExporter=true
+Telemetry__OtlpProtocol=HttpProtobuf
+Telemetry__OtlpEndpoint=http://otel-collector:4318
+```
+
+If headers are required (e.g. an authenticating gateway):
 
 ```
 Telemetry__OtlpHeaders=api-key=XYZ123
 ```
+
+All three signals — traces, metrics and logs — are exported to the same endpoint. This
+suits a collector-based topology where the collector fans out to backends (e.g. exporting
+everything to Elasticsearch). Providers are flushed on graceful shutdown by the
+`OpenTelemetry.Extensions.Hosting` integration.
+
+If the collector only accepts plaintext gRPC (no TLS), set `Telemetry__OtlpInsecure=true`;
+this enables the runtime's HTTP/2-cleartext (h2c) support required for gRPC over `http://`.
 
 ### Docker Compose Example (Prometheus + Collector)
 
@@ -722,7 +740,10 @@ The application container only needs relevant environment variables; `/metrics` 
 
 ### Log Export
 
-Currently logs go through the OpenTelemetry logging provider. If an OTLP exporter is enabled they will be forwarded to the collector; otherwise they remain local (console).
+Logs go through the OpenTelemetry logging provider. When the OTLP exporter is enabled
+(`EnableOtlpExporter=true` with an endpoint) log records are exported to the collector over
+OTLP using the same endpoint/protocol/headers as traces and metrics. Without OTLP enabled
+they remain local (console, in Development or when `LOG_CONSOLE_DEV=true`).
 
 ### Tag / Attribute Conventions (Initial)
 

--- a/README.md
+++ b/README.md
@@ -669,8 +669,7 @@ If enabled (default), metrics are exposed at `GET /metrics` using the Prometheus
 | `EnableOtlpExporter`    | false                  | Enable OTLP exporter for traces/metrics/logs                   |
 | `OtlpEndpoint`          | null                   | OTLP endpoint (e.g. `http://otel-collector:4317` for gRPC)     |
 | `OtlpProtocol`          | Grpc                   | Wire protocol: `Grpc` (port 4317) or `HttpProtobuf` (port 4318)|
-| `OtlpHeaders`           | null                   | Additional OTLP headers (key=value;key2=value2)                |
-| `OtlpInsecure`          | false                  | Allow gRPC over plaintext `http://` (enables HTTP/2 cleartext) |
+| `OtlpHeaders`           | null                   | Additional OTLP headers, comma separated (key=value,key2=value2) |
 | `TracesSampleRatio`     | null                   | null = sample all; `0..1` = parent-based ratio sampler         |
 | `ServiceName`           | FileHorizon            | Override service.name resource attribute                       |
 | `ServiceVersion`        | Assembly version       | Override service.version                                       |
@@ -701,10 +700,11 @@ Telemetry__OtlpProtocol=HttpProtobuf
 Telemetry__OtlpEndpoint=http://otel-collector:4318
 ```
 
-If headers are required (e.g. an authenticating gateway):
+If headers are required (e.g. an authenticating gateway), supply them comma separated
+(the OTLP spec format — semicolons are not recognized as separators):
 
 ```
-Telemetry__OtlpHeaders=api-key=XYZ123
+Telemetry__OtlpHeaders=api-key=XYZ123,tenant=abc
 ```
 
 All three signals — traces, metrics and logs — are exported to the same endpoint. This
@@ -712,8 +712,8 @@ suits a collector-based topology where the collector fans out to backends (e.g. 
 everything to Elasticsearch). Providers are flushed on graceful shutdown by the
 `OpenTelemetry.Extensions.Hosting` integration.
 
-If the collector only accepts plaintext gRPC (no TLS), set `Telemetry__OtlpInsecure=true`;
-this enables the runtime's HTTP/2-cleartext (h2c) support required for gRPC over `http://`.
+A plaintext (no TLS) `http://` endpoint works out of the box for both protocols — on
+.NET 8 the runtime supports HTTP/2 cleartext (h2c) for gRPC without any opt-in switch.
 
 ### Docker Compose Example (Prometheus + Collector)
 

--- a/src/FileHorizon.Application/Configuration/TelemetryOptions.cs
+++ b/src/FileHorizon.Application/Configuration/TelemetryOptions.cs
@@ -13,7 +13,11 @@ public sealed class TelemetryOptions
     // OTLP specific
     public string? OtlpEndpoint { get; init; }
     public string? OtlpHeaders { get; init; } // semicolon or comma separated key=value list
-    public bool OtlpInsecure { get; init; } = false;
+    public bool OtlpInsecure { get; init; } = false; // allow gRPC over plaintext http:// (enables HTTP/2 cleartext)
+    public string? OtlpProtocol { get; init; } // "Grpc" (default) or "HttpProtobuf"
+
+    // Tracing
+    public double? TracesSampleRatio { get; init; } // null => sample everything; 0..1 => parent-based ratio sampler
 
     // General resource attributes
     public string? ServiceName { get; init; } // override default

--- a/src/FileHorizon.Application/Configuration/TelemetryOptions.cs
+++ b/src/FileHorizon.Application/Configuration/TelemetryOptions.cs
@@ -12,8 +12,7 @@ public sealed class TelemetryOptions
 
     // OTLP specific
     public string? OtlpEndpoint { get; init; }
-    public string? OtlpHeaders { get; init; } // semicolon or comma separated key=value list
-    public bool OtlpInsecure { get; init; } = false; // allow gRPC over plaintext http:// (enables HTTP/2 cleartext)
+    public string? OtlpHeaders { get; init; } // comma separated key=value list (OTLP spec format, e.g. "key1=v1,key2=v2")
     public string? OtlpProtocol { get; init; } // "Grpc" (default) or "HttpProtobuf"
 
     // Tracing

--- a/src/FileHorizon.Application/Configuration/TelemetryOptionsValidator.cs
+++ b/src/FileHorizon.Application/Configuration/TelemetryOptionsValidator.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Options;
+
+namespace FileHorizon.Application.Configuration;
+
+public sealed class TelemetryOptionsValidator : IValidateOptions<TelemetryOptions>
+{
+    private static readonly string[] AllowedProtocols = ["grpc", "httpprotobuf", "http/protobuf"];
+
+    public ValidateOptionsResult Validate(string? name, TelemetryOptions options)
+    {
+        if (options is null) return ValidateOptionsResult.Fail("TelemetryOptions instance is null");
+
+        var errors = new List<string>();
+
+        // !(x >= 0 && x <= 1) instead of (x < 0 || x > 1) so NaN is rejected too.
+        if (options.TracesSampleRatio is { } ratio && !(ratio >= 0 && ratio <= 1))
+        {
+            errors.Add($"Telemetry: TracesSampleRatio must be between 0 and 1, but was {ratio}");
+        }
+
+        var protocol = options.OtlpProtocol?.Trim();
+        if (!string.IsNullOrEmpty(protocol) && !AllowedProtocols.Contains(protocol.ToLowerInvariant()))
+        {
+            errors.Add($"Telemetry: OtlpProtocol '{options.OtlpProtocol}' is not supported (allowed: Grpc|HttpProtobuf)");
+        }
+
+        if (options.EnableOtlpExporter)
+        {
+            if (string.IsNullOrWhiteSpace(options.OtlpEndpoint))
+            {
+                errors.Add("Telemetry: OtlpEndpoint must be set when EnableOtlpExporter is true");
+            }
+            else if (!Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var uri)
+                || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+            {
+                // Uri.TryCreate alone accepts scheme-less "host:4317" (parsed as scheme "host"),
+                // so an explicit http/https allowlist is required to catch a missing scheme.
+                errors.Add($"Telemetry: OtlpEndpoint '{options.OtlpEndpoint}' must be an absolute http:// or https:// URI");
+            }
+        }
+
+        return errors.Count > 0 ? ValidateOptionsResult.Fail(errors) : ValidateOptionsResult.Success;
+    }
+}

--- a/src/FileHorizon.Application/ServiceCollectionExtensions.cs
+++ b/src/FileHorizon.Application/ServiceCollectionExtensions.cs
@@ -121,6 +121,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IValidateOptions<Configuration.RoutingOptions>, Configuration.RoutingOptionsValidator>();
         services.AddOptions<Configuration.TransferOptions>();
         services.AddSingleton<IValidateOptions<Configuration.TransferOptions>, Configuration.TransferOptionsValidator>();
+        services.AddOptions<Configuration.TelemetryOptions>();
+        services.AddSingleton<IValidateOptions<Configuration.TelemetryOptions>, Configuration.TelemetryOptionsValidator>();
         services.AddOptions<Configuration.IdempotencyOptions>();
         services.AddOptions<Configuration.ContentDetectionOptions>();
 

--- a/src/FileHorizon.Host/Program.cs
+++ b/src/FileHorizon.Host/Program.cs
@@ -95,6 +95,11 @@ builder.Services.AddOpenTelemetry()
         // Default to sampling everything; a configured ratio applies a parent-based ratio sampler.
         if (telemetryOptions.TracesSampleRatio is { } ratio)
         {
+            if (ratio is < 0 or > 1)
+            {
+                throw new InvalidOperationException($"Telemetry:TracesSampleRatio must be between 0 and 1, but was {ratio}.");
+            }
+
             tracing.SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(ratio)));
         }
         tracing.AddAspNetCoreInstrumentation();

--- a/src/FileHorizon.Host/Program.cs
+++ b/src/FileHorizon.Host/Program.cs
@@ -2,6 +2,7 @@ using FileHorizon.Application;
 using FileHorizon.Application.Configuration;
 using FileHorizon.Application.Common.Telemetry;
 using FileHorizon.Host.Telemetry;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -28,8 +29,14 @@ builder.Services.Configure<TelemetryOptions>(builder.Configuration.GetSection(Te
 
 var telemetryOptions = builder.Configuration.GetSection(TelemetryOptions.SectionName).Get<TelemetryOptions>() ?? new TelemetryOptions();
 
-// gRPC over a plaintext http:// endpoint needs HTTP/2 cleartext (h2c) support enabled at the runtime level.
-OtlpExporterConfig.EnableInsecureGrpcIfNeeded(telemetryOptions);
+// The telemetry pipelines below are built from this startup snapshot rather than resolved
+// IOptions<TelemetryOptions>, so validate it explicitly to fail fast on bad config
+// regardless of which telemetry features are enabled.
+var telemetryValidation = new TelemetryOptionsValidator().Validate(Options.DefaultName, telemetryOptions);
+if (telemetryValidation.Failed)
+{
+    throw new OptionsValidationException(Options.DefaultName, typeof(TelemetryOptions), telemetryValidation.Failures);
+}
 
 // Configure OpenTelemetry (Tracing, Metrics, Logging)
 var resourceBuilder = ResourceBuilder.CreateDefault()
@@ -53,7 +60,7 @@ if (telemetryOptions.EnableLogging)
         o.SetResourceBuilder(resourceBuilder);
         if (OtlpExporterConfig.IsEnabled(telemetryOptions))
         {
-            o.AddOtlpExporter(exp => OtlpExporterConfig.Apply(exp, telemetryOptions));
+            o.AddOtlpExporter(exp => OtlpExporterConfig.Apply(exp, telemetryOptions, OtlpExporterConfig.LogsPath));
         }
     });
 }
@@ -85,7 +92,7 @@ builder.Services.AddOpenTelemetry()
         }
         if (OtlpExporterConfig.IsEnabled(telemetryOptions))
         {
-            metrics.AddOtlpExporter(opt => OtlpExporterConfig.Apply(opt, telemetryOptions));
+            metrics.AddOtlpExporter(opt => OtlpExporterConfig.Apply(opt, telemetryOptions, OtlpExporterConfig.MetricsPath));
         }
     })
     .WithTracing(tracing =>
@@ -93,13 +100,9 @@ builder.Services.AddOpenTelemetry()
         if (!telemetryOptions.EnableTracing) return;
         tracing.SetResourceBuilder(resourceBuilder);
         // Default to sampling everything; a configured ratio applies a parent-based ratio sampler.
+        // Range validation happens at startup via TelemetryOptionsValidator.
         if (telemetryOptions.TracesSampleRatio is { } ratio)
         {
-            if (double.IsNaN(ratio) || double.IsInfinity(ratio) || ratio < 0 || ratio > 1)
-            {
-                throw new InvalidOperationException($"Telemetry:TracesSampleRatio must be between 0 and 1, but was {ratio}.");
-            }
-
             tracing.SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(ratio)));
         }
         tracing.AddAspNetCoreInstrumentation();
@@ -107,7 +110,7 @@ builder.Services.AddOpenTelemetry()
         tracing.AddSource(TelemetryInstrumentation.ActivitySourceName);
         if (OtlpExporterConfig.IsEnabled(telemetryOptions))
         {
-            tracing.AddOtlpExporter(opt => OtlpExporterConfig.Apply(opt, telemetryOptions));
+            tracing.AddOtlpExporter(opt => OtlpExporterConfig.Apply(opt, telemetryOptions, OtlpExporterConfig.TracesPath));
         }
     });
 

--- a/src/FileHorizon.Host/Program.cs
+++ b/src/FileHorizon.Host/Program.cs
@@ -95,7 +95,7 @@ builder.Services.AddOpenTelemetry()
         // Default to sampling everything; a configured ratio applies a parent-based ratio sampler.
         if (telemetryOptions.TracesSampleRatio is { } ratio)
         {
-            if (ratio is < 0 or > 1)
+            if (double.IsNaN(ratio) || double.IsInfinity(ratio) || ratio < 0 || ratio > 1)
             {
                 throw new InvalidOperationException($"Telemetry:TracesSampleRatio must be between 0 and 1, but was {ratio}.");
             }

--- a/src/FileHorizon.Host/Program.cs
+++ b/src/FileHorizon.Host/Program.cs
@@ -1,6 +1,7 @@
 using FileHorizon.Application;
 using FileHorizon.Application.Configuration;
 using FileHorizon.Application.Common.Telemetry;
+using FileHorizon.Host.Telemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -27,6 +28,9 @@ builder.Services.Configure<TelemetryOptions>(builder.Configuration.GetSection(Te
 
 var telemetryOptions = builder.Configuration.GetSection(TelemetryOptions.SectionName).Get<TelemetryOptions>() ?? new TelemetryOptions();
 
+// gRPC over a plaintext http:// endpoint needs HTTP/2 cleartext (h2c) support enabled at the runtime level.
+OtlpExporterConfig.EnableInsecureGrpcIfNeeded(telemetryOptions);
+
 // Configure OpenTelemetry (Tracing, Metrics, Logging)
 var resourceBuilder = ResourceBuilder.CreateDefault()
     .AddService(
@@ -47,6 +51,10 @@ if (telemetryOptions.EnableLogging)
         o.ParseStateValues = true;
         o.IncludeFormattedMessage = true;
         o.SetResourceBuilder(resourceBuilder);
+        if (OtlpExporterConfig.IsEnabled(telemetryOptions))
+        {
+            o.AddOtlpExporter(exp => OtlpExporterConfig.Apply(exp, telemetryOptions));
+        }
     });
 }
 
@@ -75,35 +83,26 @@ builder.Services.AddOpenTelemetry()
         {
             metrics.AddPrometheusExporter();
         }
-        if (telemetryOptions.EnableOtlpExporter && telemetryOptions.OtlpEndpoint is not null)
+        if (OtlpExporterConfig.IsEnabled(telemetryOptions))
         {
-            metrics.AddOtlpExporter(opt =>
-            {
-                opt.Endpoint = new Uri(telemetryOptions.OtlpEndpoint);
-                if (!string.IsNullOrWhiteSpace(telemetryOptions.OtlpHeaders))
-                {
-                    opt.Headers = telemetryOptions.OtlpHeaders;
-                }
-            });
+            metrics.AddOtlpExporter(opt => OtlpExporterConfig.Apply(opt, telemetryOptions));
         }
     })
     .WithTracing(tracing =>
     {
         if (!telemetryOptions.EnableTracing) return;
         tracing.SetResourceBuilder(resourceBuilder);
+        // Default to sampling everything; a configured ratio applies a parent-based ratio sampler.
+        if (telemetryOptions.TracesSampleRatio is { } ratio)
+        {
+            tracing.SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(ratio)));
+        }
         tracing.AddAspNetCoreInstrumentation();
         tracing.AddHttpClientInstrumentation();
         tracing.AddSource(TelemetryInstrumentation.ActivitySourceName);
-        if (telemetryOptions.EnableOtlpExporter && telemetryOptions.OtlpEndpoint is not null)
+        if (OtlpExporterConfig.IsEnabled(telemetryOptions))
         {
-            tracing.AddOtlpExporter(opt =>
-            {
-                opt.Endpoint = new Uri(telemetryOptions.OtlpEndpoint);
-                if (!string.IsNullOrWhiteSpace(telemetryOptions.OtlpHeaders))
-                {
-                    opt.Headers = telemetryOptions.OtlpHeaders;
-                }
-            });
+            tracing.AddOtlpExporter(opt => OtlpExporterConfig.Apply(opt, telemetryOptions));
         }
     });
 

--- a/src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs
+++ b/src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs
@@ -1,0 +1,60 @@
+using FileHorizon.Application.Configuration;
+using OpenTelemetry.Exporter;
+
+namespace FileHorizon.Host.Telemetry;
+
+/// <summary>
+/// Centralizes mapping from <see cref="TelemetryOptions"/> to the OTLP exporter
+/// configuration shared by the traces, metrics and logs pipelines so all three
+/// signals are exported identically to the collector.
+/// </summary>
+internal static class OtlpExporterConfig
+{
+    /// <summary>OTLP export is only attempted when explicitly enabled and an endpoint is provided.</summary>
+    public static bool IsEnabled(TelemetryOptions options) =>
+        options.EnableOtlpExporter && !string.IsNullOrWhiteSpace(options.OtlpEndpoint);
+
+    /// <summary>
+    /// Resolves the wire protocol. Defaults to gRPC (collector default on port 4317);
+    /// HTTP/Protobuf is selected for values like "HttpProtobuf" / "http/protobuf" / "http".
+    /// </summary>
+    public static OtlpExportProtocol ResolveProtocol(TelemetryOptions options) =>
+        options.OtlpProtocol?.Trim().ToLowerInvariant() switch
+        {
+            "httpprotobuf" or "http/protobuf" or "http" => OtlpExportProtocol.HttpProtobuf,
+            _ => OtlpExportProtocol.Grpc
+        };
+
+    /// <summary>Applies endpoint, protocol and optional headers to an exporter options instance.</summary>
+    public static void Apply(OtlpExporterOptions exporter, TelemetryOptions options)
+    {
+        exporter.Endpoint = new Uri(options.OtlpEndpoint!);
+        exporter.Protocol = ResolveProtocol(options);
+        if (!string.IsNullOrWhiteSpace(options.OtlpHeaders))
+        {
+            exporter.Headers = options.OtlpHeaders;
+        }
+    }
+
+    /// <summary>
+    /// gRPC over a plaintext <c>http://</c> endpoint requires HTTP/2 without TLS (h2c),
+    /// which the .NET runtime rejects unless this AppContext switch is enabled. Call once
+    /// during startup when an insecure gRPC endpoint is configured.
+    /// </summary>
+    public static void EnableInsecureGrpcIfNeeded(TelemetryOptions options)
+    {
+        if (!IsEnabled(options) || !options.OtlpInsecure)
+        {
+            return;
+        }
+
+        var isGrpc = ResolveProtocol(options) == OtlpExportProtocol.Grpc;
+        var isPlaintext = Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var uri)
+            && uri.Scheme == Uri.UriSchemeHttp;
+
+        if (isGrpc && isPlaintext)
+        {
+            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+        }
+    }
+}

--- a/src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs
+++ b/src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs
@@ -10,56 +10,63 @@ namespace FileHorizon.Host.Telemetry;
 /// </summary>
 internal static class OtlpExporterConfig
 {
+    // OTLP/HTTP per-signal paths (https://opentelemetry.io/docs/specs/otlp/#otlphttp-request).
+    public const string TracesPath = "v1/traces";
+    public const string MetricsPath = "v1/metrics";
+    public const string LogsPath = "v1/logs";
+
     /// <summary>OTLP export is only attempted when explicitly enabled and an endpoint is provided.</summary>
     public static bool IsEnabled(TelemetryOptions options) =>
         options.EnableOtlpExporter && !string.IsNullOrWhiteSpace(options.OtlpEndpoint);
 
     /// <summary>
-    /// Resolves the wire protocol. Defaults to gRPC (collector default on port 4317);
-    /// HTTP/Protobuf is selected for values like "HttpProtobuf" / "http/protobuf" / "http".
+    /// Resolves the wire protocol. Defaults to gRPC (collector default on port 4317).
+    /// Unrecognized values throw; <see cref="TelemetryOptionsValidator"/> reports the
+    /// same rule as a friendlier aggregated error at startup.
     /// </summary>
     public static OtlpExportProtocol ResolveProtocol(TelemetryOptions options) =>
         options.OtlpProtocol?.Trim().ToLowerInvariant() switch
         {
-            "httpprotobuf" or "http/protobuf" or "http" => OtlpExportProtocol.HttpProtobuf,
-            _ => OtlpExportProtocol.Grpc
+            null or "" or "grpc" => OtlpExportProtocol.Grpc,
+            "httpprotobuf" or "http/protobuf" => OtlpExportProtocol.HttpProtobuf,
+            _ => throw new InvalidOperationException($"Telemetry: OtlpProtocol '{options.OtlpProtocol}' is not supported (allowed: Grpc|HttpProtobuf).")
         };
 
-    /// <summary>Applies endpoint, protocol and optional headers to an exporter options instance.</summary>
-    public static void Apply(OtlpExporterOptions exporter, TelemetryOptions options)
+    /// <summary>
+    /// Applies endpoint, protocol and optional headers to an exporter options instance.
+    /// Assigning <see cref="OtlpExporterOptions.Endpoint"/> programmatically turns off the
+    /// SDK's automatic per-signal path appending, so for HTTP/Protobuf the signal path
+    /// (e.g. "v1/traces") is appended here unless the endpoint already includes it.
+    /// </summary>
+    public static void Apply(OtlpExporterOptions exporter, TelemetryOptions options, string signalPath)
     {
-        if (!Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var endpoint))
+        if (!Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var endpoint)
+            || (endpoint.Scheme != Uri.UriSchemeHttp && endpoint.Scheme != Uri.UriSchemeHttps))
         {
-            throw new InvalidOperationException($"Telemetry OTLP endpoint is invalid: '{options.OtlpEndpoint}'.");
+            throw new InvalidOperationException($"Telemetry OTLP endpoint is invalid: '{options.OtlpEndpoint}' (must be an absolute http:// or https:// URI).");
         }
 
-        exporter.Endpoint = endpoint;
-        exporter.Protocol = ResolveProtocol(options);
+        var protocol = ResolveProtocol(options);
+        exporter.Protocol = protocol;
+        exporter.Endpoint = protocol == OtlpExportProtocol.HttpProtobuf
+            ? AppendPathIfNotPresent(endpoint, signalPath)
+            : endpoint;
         if (!string.IsNullOrWhiteSpace(options.OtlpHeaders))
         {
             exporter.Headers = options.OtlpHeaders;
         }
     }
 
-    /// <summary>
-    /// gRPC over a plaintext <c>http://</c> endpoint requires HTTP/2 without TLS (h2c),
-    /// which the .NET runtime rejects unless this AppContext switch is enabled. Call once
-    /// during startup when an insecure gRPC endpoint is configured.
-    /// </summary>
-    public static void EnableInsecureGrpcIfNeeded(TelemetryOptions options)
+    private static Uri AppendPathIfNotPresent(Uri endpoint, string signalPath)
     {
-        if (!IsEnabled(options) || !options.OtlpInsecure)
+        var builder = new UriBuilder(endpoint);
+        var path = builder.Path.TrimEnd('/');
+        if (path.EndsWith("/" + signalPath, StringComparison.OrdinalIgnoreCase))
         {
-            return;
+            return endpoint;
         }
 
-        var isGrpc = ResolveProtocol(options) == OtlpExportProtocol.Grpc;
-        var isPlaintext = Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var uri)
-            && uri.Scheme == Uri.UriSchemeHttp;
-
-        if (isGrpc && isPlaintext)
-        {
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-        }
+        builder.Path = path + "/" + signalPath;
+        return builder.Uri;
     }
 }

--- a/src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs
+++ b/src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs
@@ -28,7 +28,12 @@ internal static class OtlpExporterConfig
     /// <summary>Applies endpoint, protocol and optional headers to an exporter options instance.</summary>
     public static void Apply(OtlpExporterOptions exporter, TelemetryOptions options)
     {
-        exporter.Endpoint = new Uri(options.OtlpEndpoint!);
+        if (!Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var endpoint))
+        {
+            throw new InvalidOperationException($"Telemetry OTLP endpoint is invalid: '{options.OtlpEndpoint}'.");
+        }
+
+        exporter.Endpoint = endpoint;
         exporter.Protocol = ResolveProtocol(options);
         if (!string.IsNullOrWhiteSpace(options.OtlpHeaders))
         {

--- a/test/FileHorizon.Application.Tests/TelemetryOptionsValidatorTests.cs
+++ b/test/FileHorizon.Application.Tests/TelemetryOptionsValidatorTests.cs
@@ -1,0 +1,90 @@
+using FileHorizon.Application.Configuration;
+
+namespace FileHorizon.Application.Tests;
+
+public sealed class TelemetryOptionsValidatorTests
+{
+    private static readonly TelemetryOptionsValidator Validator = new();
+
+    [Fact]
+    public void Defaults_are_valid()
+    {
+        Assert.True(Validator.Validate(null, new TelemetryOptions()).Succeeded);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.25)]
+    [InlineData(1.0)]
+    public void Accepts_sample_ratio_in_range(double ratio)
+    {
+        var result = Validator.Validate(null, new TelemetryOptions { TracesSampleRatio = ratio });
+        Assert.True(result.Succeeded);
+    }
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.5)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void Rejects_sample_ratio_out_of_range(double ratio)
+    {
+        var result = Validator.Validate(null, new TelemetryOptions { TracesSampleRatio = ratio });
+        Assert.True(result.Failed);
+        Assert.Contains("TracesSampleRatio", result.FailureMessage);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Grpc")]
+    [InlineData("grpc")]
+    [InlineData("HttpProtobuf")]
+    [InlineData("http/protobuf")]
+    public void Accepts_known_protocols(string? protocol)
+    {
+        var result = Validator.Validate(null, new TelemetryOptions { OtlpProtocol = protocol });
+        Assert.True(result.Succeeded);
+    }
+
+    [Theory]
+    [InlineData("Http-Protobuf")]
+    [InlineData("Protobuf")]
+    [InlineData("grcp")]
+    public void Rejects_unknown_protocols(string protocol)
+    {
+        var result = Validator.Validate(null, new TelemetryOptions { OtlpProtocol = protocol });
+        Assert.True(result.Failed);
+        Assert.Contains("OtlpProtocol", result.FailureMessage);
+    }
+
+    [Theory]
+    [InlineData("http://otel-collector:4317")]
+    [InlineData("https://otel-collector:4318/custom/path")]
+    public void Accepts_valid_endpoint_when_exporter_enabled(string endpoint)
+    {
+        var options = new TelemetryOptions { EnableOtlpExporter = true, OtlpEndpoint = endpoint };
+        Assert.True(Validator.Validate(null, options).Succeeded);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("otel-collector:4317")] // missing scheme parses as scheme "otel-collector"
+    [InlineData("ftp://otel-collector:4317")]
+    public void Rejects_missing_or_invalid_endpoint_when_exporter_enabled(string? endpoint)
+    {
+        var options = new TelemetryOptions { EnableOtlpExporter = true, OtlpEndpoint = endpoint };
+        var result = Validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Contains("OtlpEndpoint", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Endpoint_not_required_when_exporter_disabled()
+    {
+        var options = new TelemetryOptions { EnableOtlpExporter = false, OtlpEndpoint = null };
+        Assert.True(Validator.Validate(null, options).Succeeded);
+    }
+}


### PR DESCRIPTION
Closes the remaining OTLP export gaps in the Host (issue #9). OTLP was already wired for traces and metrics, but a few pieces were incomplete, non-functional, or misconfigured.

## What was broken / missing

- **Logs were never exported.** The logging pipeline built the OpenTelemetry logging provider but never attached an OTLP exporter, so log records never reached the collector — despite the README claiming they were forwarded.
- **No explicit protocol selection.** The exporter relied on the SDK default (gRPC) with no way to choose HTTP/Protobuf, and no validation of the value.
- **HTTP/Protobuf endpoints were misconfigured.** Assigning `Endpoint` programmatically disables the SDK's automatic per-signal path appending, so every signal would have been posted to the endpoint root (collector returns 404).
- **Endpoint validation was weak.** `Uri.TryCreate` alone accepts scheme-less `host:4317` strings (parsed as scheme `host`).
- Trace sampling was not configurable.
- `OtlpInsecure` was bound but unused (see resolution below).

## Changes

- **Export logs over OTLP** — added `AddOtlpExporter` to the logging pipeline so logs reach the collector using the same endpoint/protocol/headers as traces and metrics.
- **`OtlpProtocol` option** (`Grpc` | `HttpProtobuf`) for explicit protocol selection. Unrecognized values are rejected rather than silently falling back to gRPC.
- **Per-signal path handling for HTTP/Protobuf** — appends `v1/traces` / `v1/metrics` / `v1/logs` (unless already present, query string preserved), since programmatic endpoint assignment turns off the SDK's automatic appending.
- **Removed `OtlpInsecure`.** Plaintext-gRPC `http://` endpoints already work natively on `net8.0`; the `Http2UnencryptedSupport` AppContext switch it would have set is a no-op on .NET 5+, so the option was misleading and has been dropped.
- **`TracesSampleRatio` option** — applies a parent-based ratio sampler; default behaviour keeps sampling everything (`ParentBased(AlwaysOn)`).
- **`TelemetryOptionsValidator`** following the repo's `IValidateOptions` pattern (registered in DI), plus an explicit validation of the startup options snapshot in `Program.cs`. This fails fast on bad config — invalid `TracesSampleRatio` (range / NaN), unsupported `OtlpProtocol`, or a missing/non-absolute `OtlpEndpoint` when OTLP is enabled — even when the consuming pipeline is disabled.
- **Extracted `OtlpExporterConfig` helper** so traces, metrics and logs are configured identically, removing the previously duplicated exporter wiring.
- **README telemetry docs updated** — protocol, HTTP/Protobuf setup (port 4318 + `v1/*` paths), sampling, corrected log-export behaviour, `OtlpHeaders` as comma-separated (the SDK splits on commas only, not semicolons), collector→Elasticsearch topology, and a note that graceful shutdown flush is handled by `OpenTelemetry.Extensions.Hosting`.

Graceful shutdown flush required no code change — the hosting integration disposes/flushes all providers on shutdown, which is the intended pattern.

## Files

- `src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs` (new)
- `src/FileHorizon.Host/Program.cs`
- `src/FileHorizon.Application/Configuration/TelemetryOptions.cs`
- `src/FileHorizon.Application/Configuration/TelemetryOptionsValidator.cs` (new)
- `src/FileHorizon.Application/ServiceCollectionExtensions.cs` (validator registration)
- `test/FileHorizon.Application.Tests/Configuration/TelemetryOptionsValidatorTests.cs` (new)
- `README.md`

## Testing

Built and tested locally: **0 warnings, 139/139 tests passing.** `TelemetryOptionsValidatorTests` covers the sampling-ratio bounds (incl. NaN), protocol allowlist, and endpoint absoluteness rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfSTqEubBgtKPcmXExhx5a