### PR TITLE
fix(security): enforce FTPS certificate validation and SSH host key verification

### DIFF
--- a/src/FileHorizon.Application/Abstractions/ISftpClientFactory.cs
+++ b/src/FileHorizon.Application/Abstractions/ISftpClientFactory.cs
@@ -15,6 +15,8 @@ public interface ISftpClientFactory
 {
     /// <summary>
     /// Create an SFTP client using either password or private key authentication. One of password or privateKeyPem must be provided.
+    /// When <paramref name="hostKeyFingerprint"/> is set, the server host key must match it or the connection is rejected.
+    /// When <paramref name="strictHostKey"/> is true and no fingerprint is configured, the connection is rejected.
     /// </summary>
-    ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase);
+    ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase, string? hostKeyFingerprint = null, bool strictHostKey = false);
 }

--- a/src/FileHorizon.Application/Configuration/FtpSourceOptions.cs
+++ b/src/FileHorizon.Application/Configuration/FtpSourceOptions.cs
@@ -13,6 +13,12 @@ public sealed class FtpSourceOptions
     public bool Recursive { get; set; } = true;
     public int MinStableSeconds { get; set; } = 2; // stability window before considering file ready
     public bool Passive { get; set; } = true; // FTP passive mode
+    /// <summary>
+    /// If true, accept any TLS certificate presented by the server (self-signed, expired, wrong host).
+    /// SECURITY: this disables man-in-the-middle protection for FTPS. Leave false (the default) unless
+    /// connecting to a legacy server on a trusted network where certificate validation is impossible.
+    /// </summary>
+    public bool AllowInvalidCertificate { get; set; } = false;
     public string? Username { get; set; }
     public string? PasswordSecretRef { get; set; } // Key Vault or external secret reference; resolved in Host layer
     public string? DestinationPath { get; set; } // Optional override destination root

--- a/src/FileHorizon.Application/Configuration/RemoteFileSourcesOptionsValidator.cs
+++ b/src/FileHorizon.Application/Configuration/RemoteFileSourcesOptionsValidator.cs
@@ -105,6 +105,10 @@ public sealed class RemoteFileSourcesOptionsValidator : IValidateOptions<RemoteF
                 {
                     errors.Add($"{prefix}: PrivateKeyPassphraseSecretRef specified but PrivateKeySecretRef is missing.");
                 }
+                if (sftp.StrictHostKey && string.IsNullOrWhiteSpace(sftp.HostKeyFingerprint))
+                {
+                    errors.Add($"{prefix}: StrictHostKey is enabled but HostKeyFingerprint is not configured; connections would always be rejected.");
+                }
             }
         }
 

--- a/src/FileHorizon.Application/Configuration/SftpSourceOptions.cs
+++ b/src/FileHorizon.Application/Configuration/SftpSourceOptions.cs
@@ -16,7 +16,17 @@ public sealed class SftpSourceOptions
     public string? PasswordSecretRef { get; set; } // optional if using key auth
     public string? PrivateKeySecretRef { get; set; } // secret reference containing private key material
     public string? PrivateKeyPassphraseSecretRef { get; set; }
-    public string? HostKeyFingerprint { get; set; } // optional pinning
+    /// <summary>
+    /// Expected server host key fingerprint. Supports OpenSSH SHA256 format ("SHA256:&lt;base64&gt;"),
+    /// bare base64 SHA256, or legacy MD5 colon-separated hex. When set, connections to servers whose
+    /// host key does not match are rejected.
+    /// </summary>
+    public string? HostKeyFingerprint { get; set; }
+    /// <summary>
+    /// If true, require a matching <see cref="HostKeyFingerprint"/> and refuse to connect when none is
+    /// configured. If false (default), an unpinned host key is accepted with a warning logged.
+    /// </summary>
+    public bool StrictHostKey { get; set; } = false;
     public string? DestinationPath { get; set; }
     public bool CreateDestinationDirectories { get; set; } = true;
     /// <summary>

--- a/src/FileHorizon.Application/Infrastructure/FileProcessing/FileProcessingOrchestrator.cs
+++ b/src/FileHorizon.Application/Infrastructure/FileProcessing/FileProcessingOrchestrator.cs
@@ -374,7 +374,9 @@ public sealed class FileProcessingOrchestrator(
                 username: src.Username ?? string.Empty,
                 password,
                 null,
-                null
+                null,
+                hostKeyFingerprint: src.HostKeyFingerprint,
+                strictHostKey: src.StrictHostKey
             );
             await client.ConnectAsync(ct).ConfigureAwait(false);
             await client.DeleteAsync(remotePath, ct).ConfigureAwait(false);
@@ -399,7 +401,8 @@ public sealed class FileProcessingOrchestrator(
                 port: src.Port,
                 username: src.Username,
                 password: password,
-                passive: src.Passive
+                passive: src.Passive,
+                allowInvalidCertificate: src.AllowInvalidCertificate
             );
             await ftpClient.ConnectAsync(ct).ConfigureAwait(false);
             await ftpClient.DeleteAsync(remotePath, ct).ConfigureAwait(false);

--- a/src/FileHorizon.Application/Infrastructure/Polling/FtpPoller.cs
+++ b/src/FileHorizon.Application/Infrastructure/Polling/FtpPoller.cs
@@ -37,7 +37,7 @@ public sealed class FtpPoller(IFileEventQueue queue,
             // Best effort sync wait kept minimal because remote poll cycle is already async. We design secret resolution to be fast/cached.
             password = _secretResolver.ResolveSecretAsync(s.PasswordSecretRef).GetAwaiter().GetResult();
         }
-        return new FtpRemoteFileClient(_loggerFactory.CreateLogger<FtpRemoteFileClient>(), s.Host, s.Port, s.Username, password, s.Passive);
+        return new FtpRemoteFileClient(_loggerFactory.CreateLogger<FtpRemoteFileClient>(), s.Host, s.Port, s.Username, password, s.Passive, s.AllowInvalidCertificate);
     }
 
     protected override ProtocolType MapProtocolType(ProtocolType protocol) => ProtocolType.Ftp;

--- a/src/FileHorizon.Application/Infrastructure/Polling/SftpPoller.cs
+++ b/src/FileHorizon.Application/Infrastructure/Polling/SftpPoller.cs
@@ -57,7 +57,9 @@ public sealed class SftpPoller(IFileEventQueue queue,
             s.Username ?? string.Empty,
             password,
             privateKey,
-            passphrase);
+            passphrase,
+            s.HostKeyFingerprint,
+            s.StrictHostKey);
     }
 
     protected override ProtocolType MapProtocolType(ProtocolType protocol) => ProtocolType.Sftp;

--- a/src/FileHorizon.Application/Infrastructure/Processing/SftpFileContentReader.cs
+++ b/src/FileHorizon.Application/Infrastructure/Processing/SftpFileContentReader.cs
@@ -50,7 +50,7 @@ public sealed class SftpFileContentReader : IFileContentReader
             return Result<FileAttributesInfo>.Failure(Error.Validation.Invalid("Invalid SFTP file reference; host/port/path missing"));
         }
         var creds = await ResolveCredentialsAsync(file.SourceName, host, port, ct).ConfigureAwait(false);
-        await using var client = _factory.Create(host, port, creds.Username, creds.Password, creds.PrivateKeyPem, creds.PrivateKeyPassphrase);
+        await using var client = _factory.Create(host, port, creds.Username, creds.Password, creds.PrivateKeyPem, creds.PrivateKeyPassphrase, creds.HostKeyFingerprint, creds.StrictHostKey);
         try
         {
             await client.ConnectAsync(ct).ConfigureAwait(false);
@@ -76,7 +76,7 @@ public sealed class SftpFileContentReader : IFileContentReader
         }
         var creds = await ResolveCredentialsAsync(file.SourceName, host, port, ct).ConfigureAwait(false);
         // REMOVE await using (must keep client alive for stream lifetime)
-        var client = _factory.Create(host, port, creds.Username, creds.Password, creds.PrivateKeyPem, creds.PrivateKeyPassphrase);
+        var client = _factory.Create(host, port, creds.Username, creds.Password, creds.PrivateKeyPem, creds.PrivateKeyPassphrase, creds.HostKeyFingerprint, creds.StrictHostKey);
         try
         {
             await client.ConnectAsync(ct).ConfigureAwait(false);
@@ -92,13 +92,13 @@ public sealed class SftpFileContentReader : IFileContentReader
         }
     }
 
-    private async Task<(string Username, string? Password, string? PrivateKeyPem, string? PrivateKeyPassphrase)>
+    private async Task<(string Username, string? Password, string? PrivateKeyPem, string? PrivateKeyPassphrase, string? HostKeyFingerprint, bool StrictHostKey)>
         ResolveCredentialsAsync(string? sourceName, string host, int port, CancellationToken ct)
     {
         // Defaults for backward compatibility in tests or if options not bound
         if (_remoteOptions is null || _secretResolver is null)
         {
-            return ("anonymous", null, null, null);
+            return ("anonymous", null, null, null, null, false);
         }
 
         var current = _remoteOptions.CurrentValue;
@@ -111,7 +111,7 @@ public sealed class SftpFileContentReader : IFileContentReader
         {
             // No matching config; fall back to anonymous
             _logger.LogDebug("No SFTP source matched for {Host}:{Port} (sourceName={SourceName}); using anonymous", host, port, sourceName);
-            return ("anonymous", null, null, null);
+            return ("anonymous", null, null, null, null, false);
         }
 
         var username = string.IsNullOrWhiteSpace(sftp.Username) ? "anonymous" : sftp.Username!;
@@ -119,7 +119,7 @@ public sealed class SftpFileContentReader : IFileContentReader
         var privateKeyPem = await _secretResolver.ResolveSecretAsync(sftp.PrivateKeySecretRef, ct).ConfigureAwait(false);
         var privateKeyPass = await _secretResolver.ResolveSecretAsync(sftp.PrivateKeyPassphraseSecretRef, ct).ConfigureAwait(false);
 
-        return (username, password, privateKeyPem, privateKeyPass);
+        return (username, password, privateKeyPem, privateKeyPass, sftp.HostKeyFingerprint, sftp.StrictHostKey);
     }
 
     private static bool TryResolveEndpoint(FileReference file, out string host, out int port, out string path)

--- a/src/FileHorizon.Application/Infrastructure/Remote/FtpRemoteFileClient.cs
+++ b/src/FileHorizon.Application/Infrastructure/Remote/FtpRemoteFileClient.cs
@@ -28,6 +28,11 @@ public sealed class FtpRemoteFileClient(ILogger<FtpRemoteFileClient> logger, str
     public async Task ConnectAsync(CancellationToken ct)
     {
         if (_client != null && _client.IsConnected) return;
+        if (_client != null)
+        {
+            _client.Dispose();
+            _client = null;
+        }
         if (_allowInvalidCertificate)
         {
             _logger.LogWarning("TLS certificate validation is disabled for FTP source {Host}:{Port} (AllowInvalidCertificate=true); the connection is not protected against man-in-the-middle attacks", _host, _port);
@@ -40,16 +45,17 @@ public sealed class FtpRemoteFileClient(ILogger<FtpRemoteFileClient> logger, str
                 ValidateAnyCertificate = _allowInvalidCertificate
             }
         };
-        _client = client;
         try
         {
             await client.Connect(ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
+            client.Dispose();
             _logger.LogWarning(ex, "FTP connect failed to {Host}:{Port}", _host, _port);
             throw;
         }
+        _client = client;
     }
 
     public async IAsyncEnumerable<IRemoteFileInfo> ListFilesAsync(string path, bool recursive, string pattern, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)

--- a/src/FileHorizon.Application/Infrastructure/Remote/FtpRemoteFileClient.cs
+++ b/src/FileHorizon.Application/Infrastructure/Remote/FtpRemoteFileClient.cs
@@ -10,7 +10,7 @@ namespace FileHorizon.Application.Infrastructure.Remote;
 /// FTP implementation of <see cref="IRemoteFileClient"/> using FluentFTP.
 /// Connection lifecycle: created per poll cycle (caller controls lifetime).
 /// </summary>
-public sealed class FtpRemoteFileClient(ILogger<FtpRemoteFileClient> logger, string host, int port, string? username, string? password, bool passive) : IRemoteFileClient
+public sealed class FtpRemoteFileClient(ILogger<FtpRemoteFileClient> logger, string host, int port, string? username, string? password, bool passive, bool allowInvalidCertificate = false) : IRemoteFileClient
 {
     private readonly ILogger<FtpRemoteFileClient> _logger = logger;
     private readonly string _host = host;
@@ -18,6 +18,7 @@ public sealed class FtpRemoteFileClient(ILogger<FtpRemoteFileClient> logger, str
     private readonly string? _username = string.IsNullOrWhiteSpace(username) ? "anonymous" : username;
     private readonly string? _password = password ?? "anonymous@"; // already resolved secret (host layer) when provided
     private readonly bool _passive = passive;
+    private readonly bool _allowInvalidCertificate = allowInvalidCertificate;
     private AsyncFtpClient? _client;
 
     public ProtocolType Protocol => ProtocolType.Ftp;
@@ -27,12 +28,16 @@ public sealed class FtpRemoteFileClient(ILogger<FtpRemoteFileClient> logger, str
     public async Task ConnectAsync(CancellationToken ct)
     {
         if (_client != null && _client.IsConnected) return;
+        if (_allowInvalidCertificate)
+        {
+            _logger.LogWarning("TLS certificate validation is disabled for FTP source {Host}:{Port} (AllowInvalidCertificate=true); the connection is not protected against man-in-the-middle attacks", _host, _port);
+        }
         var client = new AsyncFtpClient(_host, _username, _password, _port)
         {
             Config =
             {
                 DataConnectionType = _passive ? FtpDataConnectionType.PASV : FtpDataConnectionType.PORT,
-                ValidateAnyCertificate = true // TODO: optionally tighten later with configuration
+                ValidateAnyCertificate = _allowInvalidCertificate
             }
         };
         _client = client;

--- a/src/FileHorizon.Application/Infrastructure/Remote/SftpRemoteFileClient.cs
+++ b/src/FileHorizon.Application/Infrastructure/Remote/SftpRemoteFileClient.cs
@@ -20,6 +20,8 @@ public sealed class SftpRemoteFileClient : IRemoteFileClient
     private readonly string? _password;
     private readonly string? _privateKeyPem;
     private readonly string? _privateKeyPassphrase;
+    private readonly string? _hostKeyFingerprint;
+    private readonly bool _strictHostKey;
     private SftpClient? _client;
 
     public SftpRemoteFileClient(
@@ -29,7 +31,9 @@ public sealed class SftpRemoteFileClient : IRemoteFileClient
         string username,
         string? password,
         string? privateKeyPem,
-        string? privateKeyPassphrase)
+        string? privateKeyPassphrase,
+        string? hostKeyFingerprint = null,
+        bool strictHostKey = false)
     {
         _logger = logger;
         _host = host;
@@ -38,6 +42,8 @@ public sealed class SftpRemoteFileClient : IRemoteFileClient
         _password = password;
         _privateKeyPem = privateKeyPem;
         _privateKeyPassphrase = privateKeyPassphrase;
+        _hostKeyFingerprint = hostKeyFingerprint;
+        _strictHostKey = strictHostKey;
     }
 
     public ProtocolType Protocol => ProtocolType.Sftp;
@@ -63,15 +69,22 @@ public sealed class SftpRemoteFileClient : IRemoteFileClient
 
     private SftpClient CreateClient()
     {
+        SftpClient client;
         if (!string.IsNullOrWhiteSpace(_privateKeyPem))
         {
             using var keyStream = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(_privateKeyPem));
             PrivateKeyFile pkFile = string.IsNullOrWhiteSpace(_privateKeyPassphrase)
                 ? new PrivateKeyFile(keyStream)
                 : new PrivateKeyFile(keyStream, _privateKeyPassphrase);
-            return new SftpClient(_host, _port, _username, new PrivateKeyFile[] { pkFile });
+            client = new SftpClient(_host, _port, _username, new PrivateKeyFile[] { pkFile });
         }
-        return new SftpClient(_host, _port, _username, _password ?? string.Empty);
+        else
+        {
+            client = new SftpClient(_host, _port, _username, _password ?? string.Empty);
+        }
+        client.HostKeyReceived += (_, e) =>
+            e.CanTrust = SshHostKeyValidator.Validate(_logger, _host, _port, _hostKeyFingerprint, _strictHostKey, e.HostKeyName, e.HostKey);
+        return client;
     }
 
     public async IAsyncEnumerable<IRemoteFileInfo> ListFilesAsync(string path, bool recursive, string pattern, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)

--- a/src/FileHorizon.Application/Infrastructure/Remote/SftpRemoteFileClient.cs
+++ b/src/FileHorizon.Application/Infrastructure/Remote/SftpRemoteFileClient.cs
@@ -53,17 +53,24 @@ public sealed class SftpRemoteFileClient : IRemoteFileClient
     public Task ConnectAsync(CancellationToken ct)
     {
         if (_client != null && _client.IsConnected) return Task.CompletedTask;
+        if (_client != null)
+        {
+            _client.Dispose();
+            _client = null;
+        }
 
-        _client = CreateClient();
+        var client = CreateClient();
         try
         {
-            _client.Connect();
+            client.Connect();
         }
         catch (Exception ex)
         {
+            client.Dispose();
             _logger.LogWarning(ex, "SFTP connect failed to {Host}:{Port}", _host, _port);
             throw;
         }
+        _client = client;
         return Task.CompletedTask;
     }
 

--- a/src/FileHorizon.Application/Infrastructure/Remote/SshHostKeyValidator.cs
+++ b/src/FileHorizon.Application/Infrastructure/Remote/SshHostKeyValidator.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.Logging;
+using System.Security.Cryptography;
+
+namespace FileHorizon.Application.Infrastructure.Remote;
+
+/// <summary>
+/// Validates SSH server host keys against an operator-configured pinned fingerprint.
+/// Supported fingerprint formats: OpenSSH SHA256 ("SHA256:&lt;base64&gt;"), bare base64 SHA256,
+/// and legacy MD5 hex pairs separated by colons ("16:27:ac:...").
+/// </summary>
+public static class SshHostKeyValidator
+{
+    /// <summary>
+    /// Decide whether the presented host key can be trusted.
+    /// When a fingerprint is configured it must match. When none is configured, the key is
+    /// accepted only if <paramref name="strictHostKey"/> is false (with a warning logged).
+    /// </summary>
+    public static bool Validate(ILogger logger, string host, int port, string? expectedFingerprint, bool strictHostKey, string hostKeyName, byte[] hostKey)
+    {
+        var presented = ToSha256Fingerprint(hostKey);
+        if (string.IsNullOrWhiteSpace(expectedFingerprint))
+        {
+            if (strictHostKey)
+            {
+                logger.LogError("Rejecting SSH host key for {Host}:{Port}: StrictHostKey is enabled but no HostKeyFingerprint is configured. Presented key: {KeyType} {Fingerprint}", host, port, hostKeyName, presented);
+                return false;
+            }
+            logger.LogWarning("SSH host key for {Host}:{Port} is NOT verified (no HostKeyFingerprint configured). Presented key: {KeyType} {Fingerprint}. Configure HostKeyFingerprint to protect against man-in-the-middle attacks", host, port, hostKeyName, presented);
+            return true;
+        }
+
+        if (FingerprintMatches(expectedFingerprint, hostKey))
+        {
+            logger.LogDebug("SSH host key for {Host}:{Port} matched configured fingerprint ({KeyType} {Fingerprint})", host, port, hostKeyName, presented);
+            return true;
+        }
+
+        logger.LogError("Rejecting SSH host key for {Host}:{Port}: presented key {KeyType} {Fingerprint} does not match configured HostKeyFingerprint", host, port, hostKeyName, presented);
+        return false;
+    }
+
+    /// <summary>
+    /// Compare a configured fingerprint string against the raw host key bytes.
+    /// </summary>
+    public static bool FingerprintMatches(string expectedFingerprint, byte[] hostKey)
+    {
+        var expected = expectedFingerprint.Trim();
+
+        if (expected.Contains(':') && !expected.StartsWith("SHA256:", StringComparison.OrdinalIgnoreCase))
+        {
+            // Legacy MD5 format: colon-separated hex pairs.
+            var md5 = Convert.ToHexString(MD5.HashData(hostKey));
+            var expectedHex = expected.Replace(":", string.Empty);
+            return string.Equals(md5, expectedHex, StringComparison.OrdinalIgnoreCase);
+        }
+
+        if (expected.StartsWith("SHA256:", StringComparison.OrdinalIgnoreCase))
+        {
+            expected = expected["SHA256:".Length..];
+        }
+        // OpenSSH prints SHA256 fingerprints as unpadded base64.
+        var sha256 = Convert.ToBase64String(SHA256.HashData(hostKey)).TrimEnd('=');
+        return string.Equals(sha256, expected.TrimEnd('='), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// OpenSSH-style SHA256 fingerprint ("SHA256:&lt;unpadded base64&gt;") of a host key, for logging.
+    /// </summary>
+    public static string ToSha256Fingerprint(byte[] hostKey)
+        => "SHA256:" + Convert.ToBase64String(SHA256.HashData(hostKey)).TrimEnd('=');
+}

--- a/src/FileHorizon.Application/Infrastructure/Remote/SshNetSftpClientAdapter.cs
+++ b/src/FileHorizon.Application/Infrastructure/Remote/SshNetSftpClientAdapter.cs
@@ -10,7 +10,7 @@ public sealed class SshNetSftpClientFactory(ILogger<SshNetSftpClientFactory> log
 {
     private readonly ILogger<SshNetSftpClientFactory> _logger = logger;
 
-    public FileHorizon.Application.Abstractions.ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase)
+    public FileHorizon.Application.Abstractions.ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase, string? hostKeyFingerprint = null, bool strictHostKey = false)
     {
         // Build ConnectionInfo
         ConnectionInfo connInfo;
@@ -30,6 +30,8 @@ public sealed class SshNetSftpClientFactory(ILogger<SshNetSftpClientFactory> log
         }
 
         var client = new SftpClient(connInfo);
+        client.HostKeyReceived += (_, e) =>
+            e.CanTrust = SshHostKeyValidator.Validate(_logger, host, port, hostKeyFingerprint, strictHostKey, e.HostKeyName, e.HostKey);
         return new SshNetSftpClientWrapper(_logger, client);
     }
 

--- a/test/FileHorizon.Application.Tests/SftpFileContentReaderTests.cs
+++ b/test/FileHorizon.Application.Tests/SftpFileContentReaderTests.cs
@@ -24,7 +24,7 @@ public sealed class SftpFileContentReaderTests
     {
         private readonly ISftpClient _client;
         public FakeFactory(ISftpClient client) { _client = client; }
-        public ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase) => _client;
+        public ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase, string? hostKeyFingerprint = null, bool strictHostKey = false) => _client;
     }
 
     [Fact]

--- a/test/FileHorizon.Application.Tests/SshHostKeyValidatorTests.cs
+++ b/test/FileHorizon.Application.Tests/SshHostKeyValidatorTests.cs
@@ -1,0 +1,81 @@
+using System.Security.Cryptography;
+using System.Text;
+using FileHorizon.Application.Infrastructure.Remote;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FileHorizon.Application.Tests;
+
+public sealed class SshHostKeyValidatorTests
+{
+    private static readonly byte[] HostKey = Encoding.UTF8.GetBytes("fake-ssh-host-key-material");
+
+    private static string Sha256Base64Unpadded() =>
+        Convert.ToBase64String(SHA256.HashData(HostKey)).TrimEnd('=');
+
+    private static string Md5ColonHex()
+    {
+        var hex = Convert.ToHexString(MD5.HashData(HostKey)).ToLowerInvariant();
+        return string.Join(':', Enumerable.Range(0, hex.Length / 2).Select(i => hex.Substring(i * 2, 2)));
+    }
+
+    [Fact]
+    public void Matches_openssh_sha256_format()
+    {
+        Assert.True(SshHostKeyValidator.FingerprintMatches($"SHA256:{Sha256Base64Unpadded()}", HostKey));
+    }
+
+    [Fact]
+    public void Matches_bare_base64_sha256()
+    {
+        Assert.True(SshHostKeyValidator.FingerprintMatches(Sha256Base64Unpadded(), HostKey));
+    }
+
+    [Fact]
+    public void Matches_padded_base64_sha256()
+    {
+        Assert.True(SshHostKeyValidator.FingerprintMatches(Convert.ToBase64String(SHA256.HashData(HostKey)), HostKey));
+    }
+
+    [Fact]
+    public void Matches_legacy_md5_colon_hex()
+    {
+        Assert.True(SshHostKeyValidator.FingerprintMatches(Md5ColonHex(), HostKey));
+        Assert.True(SshHostKeyValidator.FingerprintMatches(Md5ColonHex().ToUpperInvariant(), HostKey));
+    }
+
+    [Fact]
+    public void Rejects_wrong_fingerprint()
+    {
+        var other = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes("different-key"))).TrimEnd('=');
+        Assert.False(SshHostKeyValidator.FingerprintMatches($"SHA256:{other}", HostKey));
+        Assert.False(SshHostKeyValidator.FingerprintMatches("16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48", HostKey));
+    }
+
+    [Fact]
+    public void Validate_accepts_matching_fingerprint()
+    {
+        var ok = SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, $"SHA256:{Sha256Base64Unpadded()}", strictHostKey: true, "ssh-ed25519", HostKey);
+        Assert.True(ok);
+    }
+
+    [Fact]
+    public void Validate_rejects_mismatched_fingerprint()
+    {
+        var ok = SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", strictHostKey: false, "ssh-ed25519", HostKey);
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void Validate_without_fingerprint_rejects_when_strict()
+    {
+        var ok = SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, null, strictHostKey: true, "ssh-ed25519", HostKey);
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void Validate_without_fingerprint_accepts_when_not_strict()
+    {
+        var ok = SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, null, strictHostKey: false, "ssh-ed25519", HostKey);
+        Assert.True(ok);
+    }
+}


### PR DESCRIPTION
## Summary

Hardens transport security in the remote-file client layer for FTPS and SFTP connections.

### FTPS

- `FtpRemoteFileClient` now uses FluentFTP's default TLS certificate validation (CA chain + hostname) instead of accepting any certificate.
- New `FtpSourceOptions.AllowInvalidCertificate` (default `false`) provides an explicit per-source opt-out for legacy servers; a warning is logged on connect when enabled.

### SFTP

- Server host keys are now verified via a `HostKeyReceived` handler in both SFTP clients, backed by a new shared `SshHostKeyValidator`.
- `SftpSourceOptions.HostKeyFingerprint` (previously declared but unused) is now enforced. Supported formats: OpenSSH `SHA256:<base64>`, bare base64 SHA256, and legacy MD5 colon-hex. On mismatch the connection is rejected and the presented fingerprint is logged so operators can pin it.
- New `SftpSourceOptions.StrictHostKey` (default `false`) requires a configured fingerprint; `RemoteFileSourcesOptionsValidator` fails fast at startup if it is enabled without one.
- Wired through all connection paths: `SshNetSftpClientFactory` (via extended `ISftpClientFactory.Create`), `SftpRemoteFileClient` (`SftpPoller` and orchestrator delete path), and `SftpFileContentReader`.

### Notes

- `SftpDestinationOptions.StrictHostKey` remains unwired because SFTP destination handling is not implemented yet (`Destination.SftpUnsupported`).
- Defaults preserve existing behavior for unpinned SFTP sources (accept with a warning), so this is non-breaking for current deployments.

## Testing

- `dotnet build /warnaserror` clean on Release.
- All tests pass (114 passed, 3 pre-existing skips), including 9 new `SshHostKeyValidatorTests` covering fingerprint formats, mismatch rejection, and strict-mode behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)