### PR TITLE
fix(telemetry): suggested changes for PR #24 review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,8 +669,7 @@ If enabled (default), metrics are exposed at `GET /metrics` using the Prometheus
 | `EnableOtlpExporter`    | false                  | Enable OTLP exporter for traces/metrics/logs                   |
 | `OtlpEndpoint`          | null                   | OTLP endpoint (e.g. `http://otel-collector:4317` for gRPC)     |
 | `OtlpProtocol`          | Grpc                   | Wire protocol: `Grpc` (port 4317) or `HttpProtobuf` (port 4318)|
-| `OtlpHeaders`           | null                   | Additional OTLP headers (key=value;key2=value2)                |
-| `OtlpInsecure`          | false                  | Allow gRPC over plaintext `http://` (enables HTTP/2 cleartext) |
+| `OtlpHeaders`           | null                   | Additional OTLP headers, comma separated (key=value,key2=value2) |
 | `TracesSampleRatio`     | null                   | null = sample all; `0..1` = parent-based ratio sampler         |
 | `ServiceName`           | FileHorizon            | Override service.name resource attribute                       |
 | `ServiceVersion`        | Assembly version       | Override service.version                                       |
@@ -701,10 +700,11 @@ Telemetry__OtlpProtocol=HttpProtobuf
 Telemetry__OtlpEndpoint=http://otel-collector:4318
 ```
 
-If headers are required (e.g. an authenticating gateway):
+If headers are required (e.g. an authenticating gateway), supply them comma separated
+(the OTLP spec format — semicolons are not recognized as separators):
 
 ```
-Telemetry__OtlpHeaders=api-key=XYZ123
+Telemetry__OtlpHeaders=api-key=XYZ123,tenant=abc
 ```
 
 All three signals — traces, metrics and logs — are exported to the same endpoint. This
@@ -712,8 +712,8 @@ suits a collector-based topology where the collector fans out to backends (e.g. 
 everything to Elasticsearch). Providers are flushed on graceful shutdown by the
 `OpenTelemetry.Extensions.Hosting` integration.
 
-If the collector only accepts plaintext gRPC (no TLS), set `Telemetry__OtlpInsecure=true`;
-this enables the runtime's HTTP/2-cleartext (h2c) support required for gRPC over `http://`.
+A plaintext (no TLS) `http://` endpoint works out of the box for both protocols — on
+.NET 8 the runtime supports HTTP/2 cleartext (h2c) for gRPC without any opt-in switch.
 
 ### Docker Compose Example (Prometheus + Collector)
 

--- a/src/FileHorizon.Application/Configuration/TelemetryOptions.cs
+++ b/src/FileHorizon.Application/Configuration/TelemetryOptions.cs
@@ -12,8 +12,7 @@ public sealed class TelemetryOptions
 
     // OTLP specific
     public string? OtlpEndpoint { get; init; }
-    public string? OtlpHeaders { get; init; } // semicolon or comma separated key=value list
-    public bool OtlpInsecure { get; init; } = false; // allow gRPC over plaintext http:// (enables HTTP/2 cleartext)
+    public string? OtlpHeaders { get; init; } // comma separated key=value list (OTLP spec format, e.g. "key1=v1,key2=v2")
     public string? OtlpProtocol { get; init; } // "Grpc" (default) or "HttpProtobuf"
 
     // Tracing

--- a/src/FileHorizon.Application/Configuration/TelemetryOptionsValidator.cs
+++ b/src/FileHorizon.Application/Configuration/TelemetryOptionsValidator.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Options;
+
+namespace FileHorizon.Application.Configuration;
+
+public sealed class TelemetryOptionsValidator : IValidateOptions<TelemetryOptions>
+{
+    private static readonly string[] AllowedProtocols = ["grpc", "httpprotobuf", "http/protobuf"];
+
+    public ValidateOptionsResult Validate(string? name, TelemetryOptions options)
+    {
+        if (options is null) return ValidateOptionsResult.Fail("TelemetryOptions instance is null");
+
+        var errors = new List<string>();
+
+        // !(x >= 0 && x <= 1) instead of (x < 0 || x > 1) so NaN is rejected too.
+        if (options.TracesSampleRatio is { } ratio && !(ratio >= 0 && ratio <= 1))
+        {
+            errors.Add($"Telemetry: TracesSampleRatio must be between 0 and 1, but was {ratio}");
+        }
+
+        var protocol = options.OtlpProtocol?.Trim();
+        if (!string.IsNullOrEmpty(protocol) && !AllowedProtocols.Contains(protocol.ToLowerInvariant()))
+        {
+            errors.Add($"Telemetry: OtlpProtocol '{options.OtlpProtocol}' is not supported (allowed: Grpc|HttpProtobuf)");
+        }
+
+        if (options.EnableOtlpExporter)
+        {
+            if (string.IsNullOrWhiteSpace(options.OtlpEndpoint))
+            {
+                errors.Add("Telemetry: OtlpEndpoint must be set when EnableOtlpExporter is true");
+            }
+            else if (!Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var uri)
+                || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+            {
+                // Uri.TryCreate alone accepts scheme-less "host:4317" (parsed as scheme "host"),
+                // so an explicit http/https allowlist is required to catch a missing scheme.
+                errors.Add($"Telemetry: OtlpEndpoint '{options.OtlpEndpoint}' must be an absolute http:// or https:// URI");
+            }
+        }
+
+        return errors.Count > 0 ? ValidateOptionsResult.Fail(errors) : ValidateOptionsResult.Success;
+    }
+}

--- a/src/FileHorizon.Application/ServiceCollectionExtensions.cs
+++ b/src/FileHorizon.Application/ServiceCollectionExtensions.cs
@@ -121,6 +121,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IValidateOptions<Configuration.RoutingOptions>, Configuration.RoutingOptionsValidator>();
         services.AddOptions<Configuration.TransferOptions>();
         services.AddSingleton<IValidateOptions<Configuration.TransferOptions>, Configuration.TransferOptionsValidator>();
+        services.AddOptions<Configuration.TelemetryOptions>();
+        services.AddSingleton<IValidateOptions<Configuration.TelemetryOptions>, Configuration.TelemetryOptionsValidator>();
         services.AddOptions<Configuration.IdempotencyOptions>();
         services.AddOptions<Configuration.ContentDetectionOptions>();
 

--- a/src/FileHorizon.Host/Program.cs
+++ b/src/FileHorizon.Host/Program.cs
@@ -2,6 +2,7 @@ using FileHorizon.Application;
 using FileHorizon.Application.Configuration;
 using FileHorizon.Application.Common.Telemetry;
 using FileHorizon.Host.Telemetry;
+using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -28,8 +29,14 @@ builder.Services.Configure<TelemetryOptions>(builder.Configuration.GetSection(Te
 
 var telemetryOptions = builder.Configuration.GetSection(TelemetryOptions.SectionName).Get<TelemetryOptions>() ?? new TelemetryOptions();
 
-// gRPC over a plaintext http:// endpoint needs HTTP/2 cleartext (h2c) support enabled at the runtime level.
-OtlpExporterConfig.EnableInsecureGrpcIfNeeded(telemetryOptions);
+// The telemetry pipelines below are built from this startup snapshot rather than resolved
+// IOptions<TelemetryOptions>, so validate it explicitly to fail fast on bad config
+// regardless of which telemetry features are enabled.
+var telemetryValidation = new TelemetryOptionsValidator().Validate(Options.DefaultName, telemetryOptions);
+if (telemetryValidation.Failed)
+{
+    throw new OptionsValidationException(Options.DefaultName, typeof(TelemetryOptions), telemetryValidation.Failures);
+}
 
 // Configure OpenTelemetry (Tracing, Metrics, Logging)
 var resourceBuilder = ResourceBuilder.CreateDefault()
@@ -53,7 +60,7 @@ if (telemetryOptions.EnableLogging)
         o.SetResourceBuilder(resourceBuilder);
         if (OtlpExporterConfig.IsEnabled(telemetryOptions))
         {
-            o.AddOtlpExporter(exp => OtlpExporterConfig.Apply(exp, telemetryOptions));
+            o.AddOtlpExporter(exp => OtlpExporterConfig.Apply(exp, telemetryOptions, OtlpExporterConfig.LogsPath));
         }
     });
 }
@@ -85,7 +92,7 @@ builder.Services.AddOpenTelemetry()
         }
         if (OtlpExporterConfig.IsEnabled(telemetryOptions))
         {
-            metrics.AddOtlpExporter(opt => OtlpExporterConfig.Apply(opt, telemetryOptions));
+            metrics.AddOtlpExporter(opt => OtlpExporterConfig.Apply(opt, telemetryOptions, OtlpExporterConfig.MetricsPath));
         }
     })
     .WithTracing(tracing =>
@@ -93,13 +100,9 @@ builder.Services.AddOpenTelemetry()
         if (!telemetryOptions.EnableTracing) return;
         tracing.SetResourceBuilder(resourceBuilder);
         // Default to sampling everything; a configured ratio applies a parent-based ratio sampler.
+        // Range validation happens at startup via TelemetryOptionsValidator.
         if (telemetryOptions.TracesSampleRatio is { } ratio)
         {
-            if (double.IsNaN(ratio) || double.IsInfinity(ratio) || ratio < 0 || ratio > 1)
-            {
-                throw new InvalidOperationException($"Telemetry:TracesSampleRatio must be between 0 and 1, but was {ratio}.");
-            }
-
             tracing.SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(ratio)));
         }
         tracing.AddAspNetCoreInstrumentation();
@@ -107,7 +110,7 @@ builder.Services.AddOpenTelemetry()
         tracing.AddSource(TelemetryInstrumentation.ActivitySourceName);
         if (OtlpExporterConfig.IsEnabled(telemetryOptions))
         {
-            tracing.AddOtlpExporter(opt => OtlpExporterConfig.Apply(opt, telemetryOptions));
+            tracing.AddOtlpExporter(opt => OtlpExporterConfig.Apply(opt, telemetryOptions, OtlpExporterConfig.TracesPath));
         }
     });
 

--- a/src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs
+++ b/src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs
@@ -10,56 +10,58 @@ namespace FileHorizon.Host.Telemetry;
 /// </summary>
 internal static class OtlpExporterConfig
 {
+    // OTLP/HTTP per-signal paths (https://opentelemetry.io/docs/specs/otlp/#otlphttp-request).
+    public const string TracesPath = "v1/traces";
+    public const string MetricsPath = "v1/metrics";
+    public const string LogsPath = "v1/logs";
+
     /// <summary>OTLP export is only attempted when explicitly enabled and an endpoint is provided.</summary>
     public static bool IsEnabled(TelemetryOptions options) =>
         options.EnableOtlpExporter && !string.IsNullOrWhiteSpace(options.OtlpEndpoint);
 
     /// <summary>
-    /// Resolves the wire protocol. Defaults to gRPC (collector default on port 4317);
-    /// HTTP/Protobuf is selected for values like "HttpProtobuf" / "http/protobuf" / "http".
+    /// Resolves the wire protocol. Defaults to gRPC (collector default on port 4317).
+    /// Unrecognized values throw; <see cref="TelemetryOptionsValidator"/> reports the
+    /// same rule as a friendlier aggregated error at startup.
     /// </summary>
     public static OtlpExportProtocol ResolveProtocol(TelemetryOptions options) =>
         options.OtlpProtocol?.Trim().ToLowerInvariant() switch
         {
-            "httpprotobuf" or "http/protobuf" or "http" => OtlpExportProtocol.HttpProtobuf,
-            _ => OtlpExportProtocol.Grpc
+            null or "" or "grpc" => OtlpExportProtocol.Grpc,
+            "httpprotobuf" or "http/protobuf" => OtlpExportProtocol.HttpProtobuf,
+            _ => throw new InvalidOperationException($"Telemetry: OtlpProtocol '{options.OtlpProtocol}' is not supported (allowed: Grpc|HttpProtobuf).")
         };
 
-    /// <summary>Applies endpoint, protocol and optional headers to an exporter options instance.</summary>
-    public static void Apply(OtlpExporterOptions exporter, TelemetryOptions options)
+    /// <summary>
+    /// Applies endpoint, protocol and optional headers to an exporter options instance.
+    /// Assigning <see cref="OtlpExporterOptions.Endpoint"/> programmatically turns off the
+    /// SDK's automatic per-signal path appending, so for HTTP/Protobuf the signal path
+    /// (e.g. "v1/traces") is appended here unless the endpoint already includes it.
+    /// </summary>
+    public static void Apply(OtlpExporterOptions exporter, TelemetryOptions options, string signalPath)
     {
-        if (!Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var endpoint))
+        if (!Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var endpoint)
+            || (endpoint.Scheme != Uri.UriSchemeHttp && endpoint.Scheme != Uri.UriSchemeHttps))
         {
-            throw new InvalidOperationException($"Telemetry OTLP endpoint is invalid: '{options.OtlpEndpoint}'.");
+            throw new InvalidOperationException($"Telemetry OTLP endpoint is invalid: '{options.OtlpEndpoint}' (must be an absolute http:// or https:// URI).");
         }
 
-        exporter.Endpoint = endpoint;
-        exporter.Protocol = ResolveProtocol(options);
+        var protocol = ResolveProtocol(options);
+        exporter.Protocol = protocol;
+        exporter.Endpoint = protocol == OtlpExportProtocol.HttpProtobuf
+            ? AppendPathIfNotPresent(endpoint, signalPath)
+            : endpoint;
         if (!string.IsNullOrWhiteSpace(options.OtlpHeaders))
         {
             exporter.Headers = options.OtlpHeaders;
         }
     }
 
-    /// <summary>
-    /// gRPC over a plaintext <c>http://</c> endpoint requires HTTP/2 without TLS (h2c),
-    /// which the .NET runtime rejects unless this AppContext switch is enabled. Call once
-    /// during startup when an insecure gRPC endpoint is configured.
-    /// </summary>
-    public static void EnableInsecureGrpcIfNeeded(TelemetryOptions options)
+    private static Uri AppendPathIfNotPresent(Uri endpoint, string signalPath)
     {
-        if (!IsEnabled(options) || !options.OtlpInsecure)
-        {
-            return;
-        }
-
-        var isGrpc = ResolveProtocol(options) == OtlpExportProtocol.Grpc;
-        var isPlaintext = Uri.TryCreate(options.OtlpEndpoint, UriKind.Absolute, out var uri)
-            && uri.Scheme == Uri.UriSchemeHttp;
-
-        if (isGrpc && isPlaintext)
-        {
-            AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-        }
+        var absolute = endpoint.AbsoluteUri.TrimEnd('/');
+        return absolute.EndsWith("/" + signalPath, StringComparison.OrdinalIgnoreCase)
+            ? endpoint
+            : new Uri(absolute + "/" + signalPath);
     }
 }

--- a/src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs
+++ b/src/FileHorizon.Host/Telemetry/OtlpExporterConfig.cs
@@ -59,9 +59,14 @@ internal static class OtlpExporterConfig
 
     private static Uri AppendPathIfNotPresent(Uri endpoint, string signalPath)
     {
-        var absolute = endpoint.AbsoluteUri.TrimEnd('/');
-        return absolute.EndsWith("/" + signalPath, StringComparison.OrdinalIgnoreCase)
-            ? endpoint
-            : new Uri(absolute + "/" + signalPath);
+        var builder = new UriBuilder(endpoint);
+        var path = builder.Path.TrimEnd('/');
+        if (path.EndsWith("/" + signalPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return endpoint;
+        }
+
+        builder.Path = path + "/" + signalPath;
+        return builder.Uri;
     }
 }

--- a/test/FileHorizon.Application.Tests/TelemetryOptionsValidatorTests.cs
+++ b/test/FileHorizon.Application.Tests/TelemetryOptionsValidatorTests.cs
@@ -1,0 +1,90 @@
+using FileHorizon.Application.Configuration;
+
+namespace FileHorizon.Application.Tests;
+
+public sealed class TelemetryOptionsValidatorTests
+{
+    private static readonly TelemetryOptionsValidator Validator = new();
+
+    [Fact]
+    public void Defaults_are_valid()
+    {
+        Assert.True(Validator.Validate(null, new TelemetryOptions()).Succeeded);
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.25)]
+    [InlineData(1.0)]
+    public void Accepts_sample_ratio_in_range(double ratio)
+    {
+        var result = Validator.Validate(null, new TelemetryOptions { TracesSampleRatio = ratio });
+        Assert.True(result.Succeeded);
+    }
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.5)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void Rejects_sample_ratio_out_of_range(double ratio)
+    {
+        var result = Validator.Validate(null, new TelemetryOptions { TracesSampleRatio = ratio });
+        Assert.True(result.Failed);
+        Assert.Contains("TracesSampleRatio", result.FailureMessage);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("Grpc")]
+    [InlineData("grpc")]
+    [InlineData("HttpProtobuf")]
+    [InlineData("http/protobuf")]
+    public void Accepts_known_protocols(string? protocol)
+    {
+        var result = Validator.Validate(null, new TelemetryOptions { OtlpProtocol = protocol });
+        Assert.True(result.Succeeded);
+    }
+
+    [Theory]
+    [InlineData("Http-Protobuf")]
+    [InlineData("Protobuf")]
+    [InlineData("grcp")]
+    public void Rejects_unknown_protocols(string protocol)
+    {
+        var result = Validator.Validate(null, new TelemetryOptions { OtlpProtocol = protocol });
+        Assert.True(result.Failed);
+        Assert.Contains("OtlpProtocol", result.FailureMessage);
+    }
+
+    [Theory]
+    [InlineData("http://otel-collector:4317")]
+    [InlineData("https://otel-collector:4318/custom/path")]
+    public void Accepts_valid_endpoint_when_exporter_enabled(string endpoint)
+    {
+        var options = new TelemetryOptions { EnableOtlpExporter = true, OtlpEndpoint = endpoint };
+        Assert.True(Validator.Validate(null, options).Succeeded);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("otel-collector:4317")] // missing scheme parses as scheme "otel-collector"
+    [InlineData("ftp://otel-collector:4317")]
+    public void Rejects_missing_or_invalid_endpoint_when_exporter_enabled(string? endpoint)
+    {
+        var options = new TelemetryOptions { EnableOtlpExporter = true, OtlpEndpoint = endpoint };
+        var result = Validator.Validate(null, options);
+        Assert.True(result.Failed);
+        Assert.Contains("OtlpEndpoint", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Endpoint_not_required_when_exporter_disabled()
+    {
+        var options = new TelemetryOptions { EnableOtlpExporter = false, OtlpEndpoint = null };
+        Assert.True(Validator.Validate(null, options).Succeeded);
+    }
+}


### PR DESCRIPTION
Suggested changes for the review findings on #24 (targets that PR's branch, so merging this lands the commits directly in #24).

## What's fixed

- **HttpProtobuf per-signal paths** — `OtlpExporterConfig.Apply` now takes the signal path (`v1/traces` / `v1/metrics` / `v1/logs`) and appends it for HTTP/Protobuf unless the configured endpoint already ends with it (mirrors the SDK's `AppendPathIfNotPresent`, which is bypassed once `Endpoint` is set programmatically). gRPC is untouched.
- **`OtlpInsecure` / h2c switch removed** — `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` does nothing on .NET 5+; plaintext gRPC to `http://` already works on net8.0. Option, switch code, and README claims removed.
- **Strict `OtlpProtocol`** — unrecognized values now fail at startup instead of silently degrading to gRPC; the undocumented bare `"http"` alias is dropped (accepted: `Grpc`, `HttpProtobuf`, `http/protobuf`, case-insensitive).
- **Endpoint scheme allowlist** — `Uri.TryCreate(..., UriKind.Absolute, ...)` accepts scheme-less `host:4317` (parsed as scheme `host`), so both the validator and `Apply` now require an absolute `http`/`https` URI.
- **`TelemetryOptionsValidator`** — new `IValidateOptions<TelemetryOptions>` following the repo's existing validator pattern, registered in `ServiceCollectionExtensions` and also run explicitly against the startup snapshot in `Program.cs` (the telemetry pipelines are built from that snapshot, not from resolved `IOptions`, so DI-time validation alone would never fire). Covers `TracesSampleRatio` (now validated even when tracing is disabled), `OtlpProtocol`, and `OtlpEndpoint` — including the previously silent `EnableOtlpExporter=true` with empty endpoint case, which is now a startup error. Unit tests included.
- **Headers docs** — the OTLP SDK splits `Headers` on commas only; README table, example, and the `TelemetryOptions` comment now say comma-separated.

## Testing

```
dotnet build   # 0 warnings, 0 errors
dotnet test    # Passed: 139, Failed: 0, Skipped: 3 (pre-existing)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
