### PR TITLE
feat(idempotency): durable identity-based tracking of already-copied files

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -56,11 +56,11 @@ Status: Implemented (baseline)
 
 ## Idempotency / Exactly-Once
 
-Status: Implemented (Initial) / Planned (Enhanced)
+Status: Implemented (Identity-based, durable)
 
-- Current: In-memory or Redis-backed (if enabled) key = `file:{FileEvent.Id}`.
-- Planned: richer identity hash (protocol + host + path + size + mtime + routing fingerprint) for cross-instance de-dup and guarding egress notifications.
-- Future: exactly-once semantics across multi-destination fan-out + egress publishes.
+- Current: key = `fh:idemp:v2:` + source identity path + size + mtime; checked before processing, marked only after successful transfer; indefinite retention by default (`TtlSeconds=0`). Stores: Redis, file-backed JSONL (`Idempotency:DataDirectory`), or in-memory fallback.
+- Planned: routing/destination fingerprint in the key to guard egress notifications; optional content hash.
+- Future: exactly-once semantics across multi-destination fan-out + egress publishes; queue ACK-after-write (Redis Streams currently ACKs on read).
 
 ## Validation & Mapping
 
@@ -101,7 +101,7 @@ Status: Implemented (Dockerfile + docker-compose present)
 | Local Sink            | Filesystem write with basic overwrite + rename pattern support.                     |
 | SFTP Reader           | SFTP source reading supported (no SFTP sink yet).                                   |
 | Redis Queue           | Pluggable Redis Streams queue with fallback to in-memory.                           |
-| Idempotency (Phase 1) | In-memory + Redis store keyed by event Id.                                          |
+| Idempotency (Phase 2) | Identity-keyed (path+size+mtime), mark-after-success; Redis/file-backed/in-memory.  |
 | Metrics (Baseline)    | Processing, queue, polling, bytes copied counters + basic histograms.               |
 | Config Model          | Destinations, Routing, Transfer, Remote sources option classes with validation.     |
 | Deletion Support      | Post-transfer deletion for local, SFTP, FTP sources (where credentials resolvable). |
@@ -114,7 +114,7 @@ Status: Implemented (Dockerfile + docker-compose present)
 | Per-destination retries           | Planned | Introduce retry abstraction & options                    |
 | SFTP Sink                         | Planned | Implement write & host key validation                    |
 | Cloud Object Store Sink (Blob/S3) | Planned | Add first cloud sink behind feature flag                 |
-| Enhanced Idempotency Key          | Planned | Derive deterministic hash & migrate store keys           |
+| Enhanced Idempotency Key          | Done    | Identity key implemented; routing fingerprint still open |
 | Service Bus Ingress               | Planned | Bridge queue -> internal events with validation          |
 | Service Bus Egress                | Planned | Publish notifications post-success with idempotent guard |
 | Router Metrics & fan-out counters | Planned | Emit `router.matches`, `router.fanout.count`             |
@@ -139,7 +139,7 @@ Status: Implemented (Dockerfile + docker-compose present)
 ### Immediate Next Increment Ideas (Refreshed)
 
 1. Multi-destination fan-out support (write loop + failure policy decision: all-or-nothing vs partial retry).
-2. Enhanced idempotency key (include identity hash) + migration path.
+2. Idempotency routing/destination fingerprint (identity key itself is done).
 3. Sink failure metric & router.matches counter.
 4. Per-destination retry/backoff configuration.
 5. Service Bus ingress bridge (scaffold + feature flag).

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Key pieces:
 - Readers: `local`, `sftp` (FTP reader pending). The orchestrator selects by `FileReference.Protocol`.
 - Router: Matches by protocol and path into a single destination (current implementation is 1:1).
 - Sinks: Currently local filesystem sink; remote sinks can be added later.
-- Idempotency: Prevents duplicate processing (in-memory or Redis-backed store).
+- Idempotency: Prevents duplicate transfers across restarts. Files are tracked by identity (`SourcePath|SizeBytes|LastModifiedUtc`, prefixed `fh:idemp:v2:`), so a modified file counts as a new version and is transferred again. The marker is written only after a successful transfer (a failed or crashed transfer is retried, never permanently suppressed). Store selection: Redis (if `Redis:Enabled`) → file-backed JSONL (if `Idempotency:DataDirectory` is set) → in-memory (non-durable).
 
 ### Source File Deletion (Event-Driven)
 
@@ -238,11 +238,12 @@ Example `appsettings.json` excerpt:
     ]
   },
   "Transfer": {
-    "ChunkSizeBytes": 32768,
-    "Idempotency": {
-      "Enabled": true,
-      "TtlSeconds": 86400
-    }
+    "ChunkSizeBytes": 32768
+  },
+  "Idempotency": {
+    "Enabled": true,
+    "TtlSeconds": 0,
+    "DataDirectory": "/var/lib/filehorizon"
   }
 }
 ```
@@ -259,14 +260,17 @@ Routing__Rules__0__Match__PathPattern=^/data/inboxA/.+\.txt$
 Routing__Rules__0__Destination=OutboxA
 
 Transfer__ChunkSizeBytes=32768
-Transfer__Idempotency__Enabled=true
-Transfer__Idempotency__TtlSeconds=86400
+Idempotency__Enabled=true
+Idempotency__TtlSeconds=0
+Idempotency__DataDirectory=/var/lib/filehorizon
 ```
 
 Notes:
 
 - On Windows, paths are normalized internally; the router matches against a normalized forward-slash path.
-- If Redis is enabled (`Redis__Enabled=true`), the idempotency store uses Redis with TTL; otherwise an in-memory store is used.
+- `Idempotency` is a top-level section (not nested under `Transfer`). `TtlSeconds=0` (the default) keeps processed-file markers forever — required for sources that keep files in place (`DeleteAfterTransfer=false`); a positive value expires markers after that many seconds.
+- Idempotency store selection: Redis when `Redis__Enabled=true`; otherwise a durable file-backed store (`idempotency.jsonl` under `Idempotency__DataDirectory`) when that directory is set; otherwise in-memory (markers do not survive restarts — a warning is logged if idempotency is enabled in this state).
+- The file-backed store grows a small line per transferred file, unbounded under indefinite retention. Deleting the file while the service is stopped resets tracking and causes at most one re-transfer per still-present source file.
 - Current sink support is local filesystem; remote sinks may be added in future.
 
 For a deeper overview see `docs/processing-architecture.md`.
@@ -625,8 +629,7 @@ Recently completed (this branch): FTP & SFTP pollers, feature flags, remote read
 
 Upcoming / still planned:
 
-- Persistent idempotency & deduplication registry (Redis / durable store)
-- Message claiming / retry hardening for Redis Streams
+- Message claiming / retry hardening for Redis Streams (queue still ACKs on read)
 - Service Bus ingress / egress bridge
 - Extended telemetry (error categorization, size histograms)
 - Configurable secret resolver (production Key Vault implementation)

--- a/README.md
+++ b/README.md
@@ -98,28 +98,32 @@ Example `appsettings.json` excerpt:
 ```json
 {
   "RemoteFileSources": {
-    "Sources": [
+    "Ftp": [
       {
         "Name": "UpstreamFtp",
-        "Protocol": "Ftp",
         "Host": "ftp.example.com",
         "Port": 21,
         "RemotePath": "/drop",
-        "UsernameSecret": "secrets:ftp-user",
-        "PasswordSecret": "secrets:ftp-pass",
-        "MinStableSeconds": 5
-      },
+        "Username": "ftpuser",
+        "PasswordSecretRef": "secrets:ftp-pass",
+        "MinStableSeconds": 5,
+        "Enabled": true
+      }
+    ],
+    "Sftp": [
       {
         "Name": "PartnerSftp",
-        "Protocol": "Sftp",
         "Host": "sftp.partner.net",
         "Port": 22,
         "RemotePath": "/inbound",
-        "UsernameSecret": "secrets:sftp-user",
-        "PasswordSecret": "secrets:sftp-pass",
-        "PrivateKeySecret": "secrets:sftp-key",
-        "PrivateKeyPassphraseSecret": "secrets:sftp-key-pass",
-        "MinStableSeconds": 8
+        "Username": "sftpuser",
+        "PasswordSecretRef": "secrets:sftp-pass",
+        "PrivateKeySecretRef": "secrets:sftp-key",
+        "PrivateKeyPassphraseSecretRef": "secrets:sftp-key-pass",
+        "HostKeyFingerprint": "SHA256:...base64...",
+        "StrictHostKey": true,
+        "MinStableSeconds": 8,
+        "Enabled": true
       }
     ]
   }
@@ -129,14 +133,13 @@ Example `appsettings.json` excerpt:
 Environment variable form (first FTP source):
 
 ```
-RemoteFileSources__Sources__0__Name=UpstreamFtp
-RemoteFileSources__Sources__0__Protocol=Ftp
-RemoteFileSources__Sources__0__Host=ftp.example.com
-RemoteFileSources__Sources__0__Port=21
-RemoteFileSources__Sources__0__RemotePath=/drop
-RemoteFileSources__Sources__0__UsernameSecret=secrets:ftp-user
-RemoteFileSources__Sources__0__PasswordSecret=secrets:ftp-pass
-RemoteFileSources__Sources__0__MinStableSeconds=5
+RemoteFileSources__Ftp__0__Name=UpstreamFtp
+RemoteFileSources__Ftp__0__Host=ftp.example.com
+RemoteFileSources__Ftp__0__Port=21
+RemoteFileSources__Ftp__0__RemotePath=/drop
+RemoteFileSources__Ftp__0__Username=ftpuser
+RemoteFileSources__Ftp__0__PasswordSecretRef=secrets:ftp-pass
+RemoteFileSources__Ftp__0__MinStableSeconds=5
 ```
 
 Validation rules enforced at startup:
@@ -148,7 +151,7 @@ Validation rules enforced at startup:
 
 ### Secrets
 
-Secrets are referenced indirectly (`UsernameSecret`, `PasswordSecret`, etc.). The application resolves them through an `ISecretResolver` abstraction. In development a simple in-memory + environment variable resolver is used; production hosts should plug in Azure Key Vault (or alternative) without changing poller code.
+Secrets are referenced indirectly (`PasswordSecretRef`, `PrivateKeySecretRef`, etc.). The application resolves them through an `ISecretResolver` abstraction. In development a simple in-memory + environment variable resolver is used; production hosts should plug in Azure Key Vault (or alternative) without changing poller code.
 
 ### Readiness (Size Stability)
 
@@ -211,8 +214,7 @@ Example `appsettings.json` excerpt:
     "Local": [
       {
         "Name": "OutboxA",
-        "BasePath": "/data/outboxA",
-        "Overwrite": true
+        "RootPath": "/data/outboxA"
       }
     ],
     "Sftp": [
@@ -220,20 +222,22 @@ Example `appsettings.json` excerpt:
         "Name": "PartnerX",
         "Host": "sftp.partner.net",
         "Port": 22,
-        "RemotePath": "/outbound",
-        "UsernameSecret": "secrets:sftp-user",
-        "PasswordSecret": "secrets:sftp-pass"
+        "RootPath": "/outbound",
+        "Username": "sftpuser",
+        "PasswordSecretRef": "secrets:sftp-pass",
+        "StrictHostKey": false
       }
     ]
   },
   "Routing": {
     "Rules": [
       {
-        "Match": {
-          "Protocol": "local",
-          "PathPattern": "^/data/inboxA/.+\\.txt$"
-        },
-        "Destination": "OutboxA"
+        "Name": "local-txt",
+        "Protocol": "local",
+        "PathGlob": "**/*.txt",
+        "Destinations": ["OutboxA"],
+        "RenamePattern": "{fileName}",
+        "Overwrite": true
       }
     ]
   },
@@ -252,12 +256,13 @@ Environment variable form (Windows PowerShell examples):
 
 ```
 Destinations__Local__0__Name=OutboxA
-Destinations__Local__0__BasePath=/data/outboxA
-Destinations__Local__0__Overwrite=true
+Destinations__Local__0__RootPath=/data/outboxA
 
-Routing__Rules__0__Match__Protocol=local
-Routing__Rules__0__Match__PathPattern=^/data/inboxA/.+\.txt$
-Routing__Rules__0__Destination=OutboxA
+Routing__Rules__0__Name=local-txt
+Routing__Rules__0__Protocol=local
+Routing__Rules__0__PathGlob=**/*.txt
+Routing__Rules__0__Destinations__0=OutboxA
+Routing__Rules__0__Overwrite=true
 
 Transfer__ChunkSizeBytes=32768
 Idempotency__Enabled=true

--- a/docs/PR_FOLLOW_UP.md
+++ b/docs/PR_FOLLOW_UP.md
@@ -7,7 +7,7 @@ Recommended GitHub issues to open after syncing architecture & roadmap docs.
 | feat: implement multi-destination fan-out | enhancement,processing  | Add loop over all routed DestinationPlans with configurable failure policy (strict vs partial).                |
 | feat: add per-destination retry policies  | enhancement,reliability | Introduce retry/backoff options section under TransferOptions for sink writes.                                 |
 | feat: introduce SFTP sink                 | enhancement,integration | Implement IFileSink for SFTP uploads (upload + mkdir -p semantics, host key verification).                     |
-| feat: enhanced idempotency key            | enhancement,idempotency | Derive composite hash (protocol+normalized path+size+mtime+routing fingerprint); migrate existing keys safely. |
+| feat: idempotency routing fingerprint     | enhancement,idempotency | Identity key (path+size+mtime) is implemented; add routing/destination fingerprint for egress guarding.        |
 | feat: service bus ingress bridge          | enhancement,integration | Bridge Service Bus queue/topic -> internal IFileEventQueue with validation + DLQ.                              |
 | feat: service bus egress publisher        | enhancement,integration | Publish file processed notifications with idempotent suppression.                                              |
 | feat: router & sink failure metrics       | telemetry,observability | Emit router.matches, router.fanout.count, sink.write.failures with labels.                                     |

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -201,8 +201,8 @@ flowchart LR
 
 ## 8. Idempotency & Exactly-Once Semantics
 
-Current: A simple key (e.g., source path + maybe timestamp) tracked via `IIdempotencyStore` prevents reprocessing within a window.
-Planned: Composite content signature (protocol + path + size + modified time + optional hash) to reduce edge collisions (see `NEXT_STEPS.md`).
+Current: A composite identity key (`fh:idemp:v2:` + source identity path + size + last-modified time) tracked via `IIdempotencyStore` prevents re-transferring files that remain at the source (e.g., `DeleteAfterTransfer=false`), including across restarts. A modified file (new size/mtime) produces a new key and is transferred as a new version. Retention defaults to indefinite (`TtlSeconds=0`); markers are written only **after** a successful transfer, so failed or crashed transfers are retried rather than suppressed (at-least-once bias). Store backends: Redis, file-backed JSONL (`Idempotency:DataDirectory`), or in-memory (non-durable).
+Planned: Optional content hash and routing/destination fingerprint in the key (see `NEXT_STEPS.md`).
 Rationale: Protects downstream sinks from duplicate side-effects; complements at-least-once delivery of queue.
 
 ## 9. Observability Model
@@ -235,7 +235,7 @@ flowchart LR
 | Local Polling | Yes                       | Enhancements (backoff)           |
 | SFTP Polling  | Yes                       | FTP/Other protocols              |
 | Queue         | Redis & InMem             | Dead-letter, retry policy        |
-| Idempotency   | Basic key store           | Composite signature, TTL mgmt    |
+| Idempotency   | Identity key (path+size+mtime), durable stores | Content hash, routing fingerprint |
 | Routing       | Pattern-based             | Conditional transforms, fan-out  |
 | Telemetry     | Core metrics/spans        | Expanded metrics, log enrichment |
 | Security      | Basic secrets abstraction | External secret provider         |

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -178,15 +178,16 @@ Configuration is centralized via `appsettings*.json` bound to strongly typed opt
 
 ```jsonc
 {
-  "Pipeline": {
-    "Sources": {
-      "Local": [{ "Path": "./_data/inboxA" }]
-    },
-    "Destinations": {
-      "Local": [{ "Name": "OutboxA", "Path": "./_data/outboxA" }]
-    },
-    "Routing": [{ "Pattern": "**/*.txt", "Destination": "OutboxA" }]
-  }
+  "FileSources": {
+    "Sources": [{ "Name": "InboxA", "Path": "./_data/inboxA", "Pattern": "*.txt" }]
+  },
+  "Destinations": {
+    "Local": [{ "Name": "OutboxA", "RootPath": "./_data/outboxA" }]
+  },
+  "Routing": {
+    "Rules": [{ "Name": "local-txt", "Protocol": "local", "PathGlob": "**/*.txt", "Destinations": ["OutboxA"] }]
+  },
+  "Idempotency": { "Enabled": true, "TtlSeconds": 0, "DataDirectory": "./_data/state" }
 }
 ```
 

--- a/docs/processing-architecture.md
+++ b/docs/processing-architecture.md
@@ -110,8 +110,8 @@ JSON example
 Yes—`IFileProcessor` is intended to be horizontally scalable.
 
 - Work distribution: Use Redis Streams consumer groups (already present). Multiple pods/containers can process in parallel without duplicate delivery.
-- Exactly‑once semantics: Implement an idempotency key derived from the file identity (protocol + normalized path + size + mtime + routing fingerprint). Store in Redis (SET or HASH) before side‑effects; treat duplicates as no‑ops.
-- ACK discipline: ACK the queue message only after all destination writes succeed and idempotency state is persisted.
+- Duplicate suppression (implemented): the idempotency key is derived from the file identity (`fh:idemp:v2:` + source identity path + size + mtime). The key is checked before processing and persisted only **after** a successful transfer, so a crash or failure mid-transfer results in a retry (at-least-once), never a permanently suppressed file. Routing fingerprint in the key remains future work.
+- ACK discipline (current gap): the Redis Streams queue still ACKs entries on read, before processing. For sources with `DeleteAfterTransfer=false` this is compensated by re-discovery — an unmarked file is re-polled and re-enqueued on the next cycle. ACK-after-write remains planned hardening.
 - Concurrency control: Apply per‑destination limits (e.g., `MaxConcurrentPerDestination`) to avoid overloading slower sinks.
 - Failure isolation: A failure to one destination in a fan‑out either (a) fails the whole event (strict), or (b) records partial success and retries the remaining subset—configurable.
 - Leases/timeouts: Use operation timeouts and safe cancellation; no shared in‑memory state is required between nodes.
@@ -168,7 +168,7 @@ These remain in the roadmap and will be added once multi-destination routing is 
 | 2    | First adapters (Local reader & sink, SFTP reader)                                        | Implemented | Local sink + local & SFTP readers registered                                     |
 | 3    | Simple router (1:1 SourceName -> Destination)                                            | Implemented | `SimpleFileRouter` returns first matching plan                                   |
 | 4    | Orchestrator replaces legacy processor                                                   | Implemented | `FileProcessingOrchestrator` registered as sole `IFileProcessor`; legacy removed |
-| 5    | Idempotency (Redis + in‑memory fallback)                                                 | Implemented | Key = `file:{FileEvent.Id}`; future richer key planned                           |
+| 5    | Idempotency (Redis / file-backed / in‑memory)                                            | Implemented | Identity key (path+size+mtime), indefinite retention, mark-after-success        |
 | 6    | Fan‑out & retries                                                                        | Planned     | Current orchestrator processes first destination only                            |
 | 7    | New sinks (SFTP, Blob, etc.)                                                             | Planned     | Only Local sink implemented; SFTP is reader-only                                 |
 | 8    | Expanded telemetry (router.\*, sink failure metrics)                                     | Planned     | Metrics subset live; additional counters pending fan‑out                         |
@@ -177,7 +177,8 @@ These remain in the roadmap and will be added once multi-destination routing is 
 
 - Single destination per file event (first route plan only).
 - No per-destination retry abstraction yet (errors propagate immediately).
-- Idempotency key is simplistic (event ID); routing/destination fingerprint not yet included.
+- Idempotency key covers file identity (path+size+mtime); routing/destination fingerprint not yet included.
+- Queue ACKs on read (pre-processing); crash recovery relies on re-discovery of unmarked files.
 - No cross-destination fan-out or partial success policy.
 - Only local writes; remote destination sinks are future work.
 
@@ -203,7 +204,7 @@ These remain in the roadmap and will be added once multi-destination routing is 
 | Concern                                     | Implemented? | Reference                                     | Next Step                                  |
 | ------------------------------------------- | ------------ | --------------------------------------------- | ------------------------------------------ |
 | Routing (single destination)                | Yes          | `SimpleFileRouter`                            | Add multi-destination fan-out              |
-| Idempotency (in-memory/Redis)               | Yes          | `IdempotencyOptions`, `RedisIdempotencyStore` | Enhance key with file identity hash        |
+| Idempotency (in-memory/file/Redis)          | Yes          | `FileIdentity`, `IdempotencyOptions`, `FileBackedIdempotencyStore`, `RedisIdempotencyStore` | Add routing fingerprint / content hash     |
 | Telemetry basic metrics                     | Yes          | `TelemetryInstrumentation`                    | Add router & sink failure metrics          |
 | Activity spans (orchestrate/read/write)     | Yes          | Orchestrator & Local sink                     | Introduce higher-level `file.process` span |
 | SFTP reader                                 | Yes          | `SftpFileContentReader`                       | Add SFTP sink implementation               |

--- a/docs/smoke-tests.md
+++ b/docs/smoke-tests.md
@@ -91,8 +91,8 @@ Notes
 
 - Orchestrator currently uses only the first matching destination (single-destination routing). Fan-out is planned.
 - Paths in rules/globs are OS-dependent; Windows paths are normalized internally for glob matching.
-- Idempotency: enable durable suppression by setting `Idempotency__Enabled=true` (backed by Redis or in-memory depending on configuration). Key currently uses the event Id; a richer identity hash is planned.
-- Redis queue + idempotency: set `Redis__Enabled=true` to activate Redis Streams + Redis-backed idempotency (if provided). Otherwise an in-memory queue/idempotency store is used (non-durable across restarts).
+- Idempotency: enable durable suppression by setting `Idempotency__Enabled=true`. Files are keyed by identity (source path + size + mtime), marked only after a successful transfer, and kept forever by default (`Idempotency__TtlSeconds=0`). Without Redis, set `Idempotency__DataDirectory=<dir>` to persist markers to `idempotency.jsonl` so they survive restarts.
+- Redis queue + idempotency: set `Redis__Enabled=true` to activate Redis Streams + Redis-backed idempotency. Otherwise the file-backed store is used when `Idempotency__DataDirectory` is set, else an in-memory store (non-durable across restarts).
 - Quick metrics checks (PowerShell):
   - `curl http://localhost:8080/metrics | Select-String files_processed`
   - `curl http://localhost:8080/metrics | Select-String poll_cycles`

--- a/src/FileHorizon.Application/Abstractions/IIdempotencyStore.cs
+++ b/src/FileHorizon.Application/Abstractions/IIdempotencyStore.cs
@@ -6,8 +6,13 @@ namespace FileHorizon.Application.Abstractions;
 public interface IIdempotencyStore
 {
     /// <summary>
+    /// Read-only check: returns true if the key is currently marked processed (and not expired).
+    /// </summary>
+    Task<bool> IsProcessedAsync(string key, CancellationToken ct);
+
+    /// <summary>
     /// Try to mark the given key as processed. Returns true if this call created the marker (i.e., not seen before),
-    /// false if the key already exists.
+    /// false if the key already exists. A null ttl means the marker never expires.
     /// </summary>
     Task<bool> TryMarkProcessedAsync(string key, TimeSpan? ttl, CancellationToken ct);
 }

--- a/src/FileHorizon.Application/Common/FileIdentity.cs
+++ b/src/FileHorizon.Application/Common/FileIdentity.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+using FileHorizon.Application.Models;
+
+namespace FileHorizon.Application.Common;
+
+/// <summary>
+/// Builds the durable idempotency key for a specific version of a file.
+/// Same source path + size + last-modified time yields the same key; any change yields a new key,
+/// so a modified file is treated as a new version and transferred again.
+/// </summary>
+public static class FileIdentity
+{
+    /// <summary>Versioned prefix so the key format can evolve without colliding with older markers.</summary>
+    public const string KeyPrefix = "fh:idemp:v2:";
+
+    public static string BuildIdempotencyKey(FileMetadata metadata)
+    {
+        var mtime = metadata.LastModifiedUtc.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+        return $"{KeyPrefix}{metadata.SourcePath}|{metadata.SizeBytes}|{mtime}";
+    }
+}

--- a/src/FileHorizon.Application/Configuration/IdempotencyOptions.cs
+++ b/src/FileHorizon.Application/Configuration/IdempotencyOptions.cs
@@ -4,5 +4,13 @@ public sealed class IdempotencyOptions
 {
     public const string SectionName = "Idempotency";
     public bool Enabled { get; set; } = false;
-    public int TtlSeconds { get; set; } = 86400; // 24h
+
+    /// <summary>Retention for processed-file markers in seconds. 0 (default) keeps markers forever.</summary>
+    public int TtlSeconds { get; set; } = 0;
+
+    /// <summary>
+    /// Directory for the file-backed durable store, used when Redis is disabled or unavailable.
+    /// When unset, marks are kept in memory only and do not survive restarts.
+    /// </summary>
+    public string? DataDirectory { get; set; }
 }

--- a/src/FileHorizon.Application/Configuration/IdempotencyOptionsValidator.cs
+++ b/src/FileHorizon.Application/Configuration/IdempotencyOptionsValidator.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Options;
+
+namespace FileHorizon.Application.Configuration;
+
+public sealed class IdempotencyOptionsValidator : IValidateOptions<IdempotencyOptions>
+{
+    public ValidateOptionsResult Validate(string? name, IdempotencyOptions options)
+    {
+        if (options is null) return ValidateOptionsResult.Fail("IdempotencyOptions instance is null");
+
+        var errors = new List<string>();
+
+        if (options.TtlSeconds < 0)
+        {
+            errors.Add($"Idempotency: TtlSeconds must not be negative (use 0 for indefinite retention), but was {options.TtlSeconds}");
+        }
+
+        if (options.DataDirectory is not null)
+        {
+            if (string.IsNullOrWhiteSpace(options.DataDirectory))
+            {
+                errors.Add("Idempotency: DataDirectory must not be empty or whitespace when set");
+            }
+            else
+            {
+                try
+                {
+                    _ = Path.GetFullPath(options.DataDirectory);
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Idempotency: DataDirectory '{options.DataDirectory}' is not a valid path ({ex.Message})");
+                }
+            }
+        }
+
+        return errors.Count > 0 ? ValidateOptionsResult.Fail(errors) : ValidateOptionsResult.Success;
+    }
+}

--- a/src/FileHorizon.Application/Infrastructure/FileProcessing/FileProcessingOrchestrator.cs
+++ b/src/FileHorizon.Application/Infrastructure/FileProcessing/FileProcessingOrchestrator.cs
@@ -51,11 +51,17 @@ public sealed class FileProcessingOrchestrator(
         activity?.SetTag("file.protocol", fileEvent.Protocol);
         activity?.SetTag("file.source_path", fileEvent.Metadata.SourcePath);
 
-        // Idempotency check (optional)
-        var idempotencyGate = await EnsureFirstProcessingAsync(fileEvent, ct).ConfigureAwait(false);
-        if (idempotencyGate.IsFailure || !idempotencyGate.Value)
+        // Idempotency check (optional): skip files whose exact version was already transferred.
+        var idemp = _idempotencyOptions.CurrentValue;
+        string? idempotencyKey = null;
+        if (idemp.Enabled)
         {
-            return idempotencyGate.IsFailure ? Result.Failure(idempotencyGate.Error) : Result.Success();
+            idempotencyKey = FileIdentity.BuildIdempotencyKey(fileEvent.Metadata);
+            if (await IsAlreadyProcessedAsync(idempotencyKey, ct).ConfigureAwait(false))
+            {
+                _logger.LogInformation("Skipping already-transferred file {Key}", idempotencyKey);
+                return Result.Success();
+            }
         }
 
         // Route to destinations (currently handle single destination only)
@@ -66,7 +72,7 @@ public sealed class FileProcessingOrchestrator(
         }
         if (planResult.Value is null)
         {
-            return Result.Success(); // nothing to do
+            return Result.Success(); // nothing to do; intentionally not marked so a routing fix transfers it
         }
         var plan = planResult.Value;
 
@@ -79,6 +85,13 @@ public sealed class FileProcessingOrchestrator(
         await using var stream = open.Value!;
 
         var dispatchResult = await DispatchDestinationAsync(fileEvent, plan, stream, ct).ConfigureAwait(false);
+
+        // Mark only after a successful transfer so a crash or failure mid-transfer is retried,
+        // never permanently suppressed (bias: rare duplicate over silent loss).
+        if (dispatchResult.IsSuccess && idempotencyKey is not null)
+        {
+            await MarkProcessedBestEffortAsync(idempotencyKey, idemp, ct).ConfigureAwait(false);
+        }
         return dispatchResult;
     }
 
@@ -245,36 +258,31 @@ public sealed class FileProcessingOrchestrator(
         return Result<DestinationPlan?>.Success(plans[0]);
     }
 
-    /// <summary>
-    /// Applies idempotency guarding. Returns Result.Success(true) when processing should continue,
-    /// Result.Success(false) when the event was already processed (and should be skipped), or a failure result
-    /// if marking the event failed unexpectedly.
-    /// </summary>
-    private async Task<Result<bool>> EnsureFirstProcessingAsync(FileEvent fileEvent, CancellationToken ct)
+    private async Task<bool> IsAlreadyProcessedAsync(string key, CancellationToken ct)
     {
-        var idemp = _idempotencyOptions.CurrentValue;
-        if (!idemp.Enabled)
-        {
-            return Result<bool>.Success(true);
-        }
-
         try
         {
-            var key = $"file:{fileEvent.Id}";
-            var ttl = TimeSpan.FromSeconds(Math.Max(1, idemp.TtlSeconds));
-            var first = await _idempotencyStore.TryMarkProcessedAsync(key, ttl, ct).ConfigureAwait(false);
-            if (!first)
-            {
-                _logger.LogInformation("Skipping already-processed file event {Id}", fileEvent.Id);
-                return Result<bool>.Success(false);
-            }
-            return Result<bool>.Success(true);
+            return await _idempotencyStore.IsProcessedAsync(key, ct).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            // Treat unexpected exception as failure so caller can decide policy (currently propagate failure)
-            _logger.LogError(ex, "Idempotency mark failed for file event {Id}", fileEvent.Id);
-            return Result<bool>.Failure(Error.Unspecified("Idempotency.MarkFailed", ex.Message));
+            // Fail open: a store outage must never permanently suppress a transfer.
+            _logger.LogWarning(ex, "Idempotency check failed for {Key}; proceeding with transfer", key);
+            return false;
+        }
+    }
+
+    private async Task MarkProcessedBestEffortAsync(string key, IdempotencyOptions idemp, CancellationToken ct)
+    {
+        try
+        {
+            TimeSpan? ttl = idemp.TtlSeconds > 0 ? TimeSpan.FromSeconds(idemp.TtlSeconds) : null;
+            await _idempotencyStore.TryMarkProcessedAsync(key, ttl, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // The transfer already succeeded; a failed mark only risks a duplicate, not loss.
+            _logger.LogWarning(ex, "Failed to mark {Key} as processed; the file may be transferred again", key);
         }
     }
 

--- a/src/FileHorizon.Application/Infrastructure/Idempotency/FileBackedIdempotencyStore.cs
+++ b/src/FileHorizon.Application/Infrastructure/Idempotency/FileBackedIdempotencyStore.cs
@@ -1,0 +1,121 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FileHorizon.Application.Abstractions;
+using Microsoft.Extensions.Logging;
+
+namespace FileHorizon.Application.Infrastructure.Idempotency;
+
+/// <summary>
+/// Durable idempotency store for deployments without Redis. Markers are kept in memory and
+/// appended to a JSONL file (one entry per line) so they survive restarts. Designed for a
+/// single process; appends are serialized, reads are lock-free against the in-memory map.
+/// With indefinite retention (null ttl) every line stays valid, so no compaction is performed.
+/// </summary>
+public sealed class FileBackedIdempotencyStore : IIdempotencyStore, IDisposable
+{
+    public const string DefaultFileName = "idempotency.jsonl";
+
+    private readonly ConcurrentDictionary<string, DateTimeOffset?> _entries = new();
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly StreamWriter _writer;
+    private readonly ILogger<FileBackedIdempotencyStore> _logger;
+
+    public FileBackedIdempotencyStore(string filePath, ILogger<FileBackedIdempotencyStore> logger)
+    {
+        _logger = logger;
+        var directory = Path.GetDirectoryName(Path.GetFullPath(filePath));
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        LoadExistingEntries(filePath);
+
+        var stream = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+        _writer = new StreamWriter(stream);
+    }
+
+    public Task<bool> IsProcessedAsync(string key, CancellationToken ct)
+    {
+        return Task.FromResult(IsActive(key));
+    }
+
+    public async Task<bool> TryMarkProcessedAsync(string key, TimeSpan? ttl, CancellationToken ct)
+    {
+        var expiry = ttl is { } t ? DateTimeOffset.UtcNow + t : (DateTimeOffset?)null;
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (IsActive(key))
+            {
+                return false;
+            }
+            _entries[key] = expiry;
+            await _writer.WriteLineAsync(JsonSerializer.Serialize(new Entry(key, expiry))).ConfigureAwait(false);
+            await _writer.FlushAsync(ct).ConfigureAwait(false);
+            return true;
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        _writer.Dispose();
+        _writeLock.Dispose();
+    }
+
+    private bool IsActive(string key)
+    {
+        return _entries.TryGetValue(key, out var expiry)
+            && (expiry is null || expiry > DateTimeOffset.UtcNow);
+    }
+
+    private void LoadExistingEntries(string filePath)
+    {
+        if (!File.Exists(filePath))
+        {
+            return;
+        }
+
+        var loaded = 0;
+        var skipped = 0;
+        foreach (var line in File.ReadLines(filePath))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            try
+            {
+                var entry = JsonSerializer.Deserialize<Entry>(line);
+                if (entry?.Key is null)
+                {
+                    skipped++;
+                    continue;
+                }
+                // Last write wins for a key that appears multiple times.
+                _entries[entry.Key] = entry.ExpiresAtUtc;
+                loaded++;
+            }
+            catch (JsonException)
+            {
+                // A torn final line after a crash is expected; skip it.
+                skipped++;
+            }
+        }
+
+        if (skipped > 0)
+        {
+            _logger.LogWarning("Idempotency file {Path}: skipped {Skipped} unreadable line(s) while loading {Loaded} marker(s)", filePath, skipped, loaded);
+        }
+        else
+        {
+            _logger.LogInformation("Idempotency file {Path}: loaded {Loaded} marker(s)", filePath, loaded);
+        }
+    }
+
+    private sealed record Entry(
+        [property: JsonPropertyName("k")] string Key,
+        [property: JsonPropertyName("e")] DateTimeOffset? ExpiresAtUtc);
+}

--- a/src/FileHorizon.Application/Infrastructure/Idempotency/InMemoryIdempotencyStore.cs
+++ b/src/FileHorizon.Application/Infrastructure/Idempotency/InMemoryIdempotencyStore.cs
@@ -5,12 +5,42 @@ namespace FileHorizon.Application.Infrastructure.Idempotency;
 
 public sealed class InMemoryIdempotencyStore : IIdempotencyStore
 {
-    private readonly ConcurrentDictionary<string, DateTimeOffset> _seen = new();
+    // Value is the expiry instant; null means the marker never expires.
+    private readonly ConcurrentDictionary<string, DateTimeOffset?> _seen = new();
+
+    public Task<bool> IsProcessedAsync(string key, CancellationToken ct)
+    {
+        return Task.FromResult(IsActive(key));
+    }
 
     public Task<bool> TryMarkProcessedAsync(string key, TimeSpan? ttl, CancellationToken ct)
     {
-        var now = DateTimeOffset.UtcNow;
-        var added = _seen.TryAdd(key, now);
-        return Task.FromResult(added);
+        var expiry = ttl is { } t ? DateTimeOffset.UtcNow + t : (DateTimeOffset?)null;
+        while (true)
+        {
+            if (_seen.TryAdd(key, expiry))
+            {
+                return Task.FromResult(true);
+            }
+            if (_seen.TryGetValue(key, out var existing))
+            {
+                if (existing is null || existing > DateTimeOffset.UtcNow)
+                {
+                    return Task.FromResult(false); // active marker already present
+                }
+                // Expired marker: replace it and treat as newly created.
+                if (_seen.TryUpdate(key, expiry, existing))
+                {
+                    return Task.FromResult(true);
+                }
+            }
+            // Lost a race; retry.
+        }
+    }
+
+    private bool IsActive(string key)
+    {
+        return _seen.TryGetValue(key, out var expiry)
+            && (expiry is null || expiry > DateTimeOffset.UtcNow);
     }
 }

--- a/src/FileHorizon.Application/Infrastructure/Idempotency/RedisIdempotencyStore.cs
+++ b/src/FileHorizon.Application/Infrastructure/Idempotency/RedisIdempotencyStore.cs
@@ -25,13 +25,26 @@ public sealed class RedisIdempotencyStore : IIdempotencyStore, IDisposable
         _db = _connection.GetDatabase();
     }
 
-    public async Task<bool> TryMarkProcessedAsync(string key, TimeSpan? ttl, CancellationToken ct)
+    public async Task<bool> IsProcessedAsync(string key, CancellationToken ct)
     {
-        var expiry = ttl ?? TimeSpan.FromHours(24);
         try
         {
-            // SET key value NX EX seconds
-            var ok = await _db.StringSetAsync(key, "1", expiry, When.NotExists).ConfigureAwait(false);
+            return await _db.KeyExistsAsync(key).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Fail open: a store outage must never permanently suppress a transfer.
+            _logger.LogWarning(ex, "Redis idempotency EXISTS failed for {Key}; treating as not processed", key);
+            return false;
+        }
+    }
+
+    public async Task<bool> TryMarkProcessedAsync(string key, TimeSpan? ttl, CancellationToken ct)
+    {
+        try
+        {
+            // SET key value NX [EX seconds]; a null ttl omits EX so the marker never expires.
+            var ok = await _db.StringSetAsync(key, "1", ttl, When.NotExists).ConfigureAwait(false);
             return ok;
         }
         catch (Exception ex)

--- a/src/FileHorizon.Application/Infrastructure/Polling/LocalDirectoryPoller.cs
+++ b/src/FileHorizon.Application/Infrastructure/Polling/LocalDirectoryPoller.cs
@@ -17,7 +17,7 @@ public sealed class LocalDirectoryPoller : IFilePoller
     private readonly IFileEventQueue _queue;
     private readonly ILogger<LocalDirectoryPoller> _logger;
     private readonly IOptionsMonitor<FileSourcesOptions> _sourcesOptions;
-    private readonly ConcurrentDictionary<string, DateTimeOffset> _seenFiles = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, (long Size, DateTime MTimeUtc)> _seenFiles = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, byte> _disabledSources = new(StringComparer.OrdinalIgnoreCase);
 
     public LocalDirectoryPoller(
@@ -111,13 +111,12 @@ public sealed class LocalDirectoryPoller : IFilePoller
         }
 
         var key = ProtocolIdentity.BuildKey(ProtocolType.Local, string.Empty, 0, fi.FullName);
-        var discovered = new DateTimeOffset(lastWrite, TimeSpan.Zero);
-        if (_seenFiles.TryGetValue(key, out var prev) && prev >= discovered)
+        if (_seenFiles.TryGetValue(key, out var prev) && prev.Size == fi.Length && prev.MTimeUtc == lastWrite)
         {
-            return; // already processed this version
+            return; // already dispatched this exact version; any size/mtime change re-dispatches
         }
 
-        _seenFiles[key] = discovered; // snapshot early
+        _seenFiles[key] = (fi.Length, lastWrite); // snapshot early
 
         var metadata = new FileMetadata(
             SourcePath: key,

--- a/src/FileHorizon.Application/Infrastructure/Polling/RemotePollerBase.cs
+++ b/src/FileHorizon.Application/Infrastructure/Polling/RemotePollerBase.cs
@@ -121,7 +121,10 @@ public abstract class RemotePollerBase : IFilePoller
 
             var key = ProtocolIdentity.BuildKey(MapProtocolType(client.Protocol), client.Host, client.Port, file.FullPath);
             _observations.TryGetValue(key, out var prev);
-            var alreadyDispatched = _dispatched.ContainsKey(key);
+            // Only the exact dispatched version counts; a changed size/mtime is a new version to re-dispatch.
+            var alreadyDispatched = _dispatched.TryGetValue(key, out var dispatchedVersion)
+                && dispatchedVersion.Size == file.Size
+                && dispatchedVersion.MTime == file.LastWriteTimeUtc;
 
             // Explain readiness decision
             if (_logger.IsEnabled(LogLevel.Trace))

--- a/src/FileHorizon.Application/ServiceCollectionExtensions.cs
+++ b/src/FileHorizon.Application/ServiceCollectionExtensions.cs
@@ -124,19 +124,50 @@ public static class ServiceCollectionExtensions
         services.AddOptions<Configuration.TelemetryOptions>();
         services.AddSingleton<IValidateOptions<Configuration.TelemetryOptions>, Configuration.TelemetryOptionsValidator>();
         services.AddOptions<Configuration.IdempotencyOptions>();
+        services.AddSingleton<IValidateOptions<Configuration.IdempotencyOptions>, Configuration.IdempotencyOptionsValidator>();
         services.AddOptions<Configuration.ContentDetectionOptions>();
 
-        // Idempotency store (choose Redis if enabled)
+        // Idempotency store selection: Redis (if enabled) -> file-backed (if DataDirectory set) -> in-memory.
         services.AddSingleton<Abstractions.IIdempotencyStore>(sp =>
         {
             var redis = sp.GetService<IOptions<RedisOptions>>()?.Value;
+            var idemp = sp.GetService<IOptions<Configuration.IdempotencyOptions>>()?.Value
+                        ?? new Configuration.IdempotencyOptions();
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
+            var logger = loggerFactory.CreateLogger("IdempotencyStoreRegistration");
             if (redis is { Enabled: true })
             {
-                return new Infrastructure.Idempotency.RedisIdempotencyStore(
-                    loggerFactory.CreateLogger<Infrastructure.Idempotency.RedisIdempotencyStore>(),
-                    sp.GetRequiredService<IOptionsMonitor<RedisOptions>>()
-                );
+                try
+                {
+                    logger.LogInformation("Using RedisIdempotencyStore");
+                    return new Infrastructure.Idempotency.RedisIdempotencyStore(
+                        loggerFactory.CreateLogger<Infrastructure.Idempotency.RedisIdempotencyStore>(),
+                        sp.GetRequiredService<IOptionsMonitor<RedisOptions>>()
+                    );
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to initialize RedisIdempotencyStore; falling back");
+                }
+            }
+            if (!string.IsNullOrWhiteSpace(idemp.DataDirectory))
+            {
+                try
+                {
+                    var path = Path.Combine(idemp.DataDirectory, Infrastructure.Idempotency.FileBackedIdempotencyStore.DefaultFileName);
+                    logger.LogInformation("Using FileBackedIdempotencyStore at {Path}", path);
+                    return new Infrastructure.Idempotency.FileBackedIdempotencyStore(
+                        path,
+                        loggerFactory.CreateLogger<Infrastructure.Idempotency.FileBackedIdempotencyStore>());
+                }
+                catch (Exception ex)
+                {
+                    logger.LogWarning(ex, "Failed to initialize FileBackedIdempotencyStore; falling back to in-memory");
+                }
+            }
+            if (idemp.Enabled)
+            {
+                logger.LogWarning("Idempotency is enabled but no durable store is configured; processed-file markers will NOT survive restarts");
             }
             return new Infrastructure.Idempotency.InMemoryIdempotencyStore();
         });

--- a/src/FileHorizon.Host/Program.cs
+++ b/src/FileHorizon.Host/Program.cs
@@ -21,6 +21,7 @@ builder.Services.Configure<DestinationsOptions>(builder.Configuration.GetSection
 builder.Services.Configure<RoutingOptions>(builder.Configuration.GetSection(RoutingOptions.SectionName));
 builder.Services.Configure<RemoteFileSourcesOptions>(builder.Configuration.GetSection(RemoteFileSourcesOptions.SectionName));
 builder.Services.Configure<TransferOptions>(builder.Configuration.GetSection(TransferOptions.SectionName));
+builder.Services.Configure<IdempotencyOptions>(builder.Configuration.GetSection(IdempotencyOptions.SectionName));
 
 builder.Services.AddHealthChecks();
 

--- a/src/FileHorizon.Host/appsettings.json
+++ b/src/FileHorizon.Host/appsettings.json
@@ -6,38 +6,171 @@
     }
   },
   "AllowedHosts": "*",
+
+  // Role: "All" runs poller + worker in one process; "Poller" / "Worker" split them (requires Redis queue).
+  "Pipeline": {
+    "Role": "All"
+  },
+
+  // Section name is "Features" (not "PipelineFeatures").
+  "Features": {
+    "EnableLocalPoller": true,
+    "EnableFtpPoller": false,
+    "EnableSftpPoller": false,
+    "EnableFileTransfer": false
+  },
+
   "Polling": {
     "IntervalMilliseconds": 1000,
     "BatchReadLimit": 10
   },
+
+  // Local directory sources. DeleteAfterTransfer=false is the scenario the new idempotency tracking is for.
   "FileSources": {
     "Sources": [
       {
-        "Name": "inbox-A",
-        "Path": "C:/Temp/FileHorizon/InboxA",
-        "Pattern": "*.*",
-        "Recursive": true,
-        "DeleteAfterTransfer": false,
+        "Name": "InboxA",
+        "Path": "C:\\data\\inboxA",
+        "Pattern": "*.txt",
+        "Recursive": false,
         "MinStableSeconds": 2,
-        "DestinationPath": "C:/Temp/FileHorizon/OutboxA",
-        "CreateDestinationDirectories": false
-      },
-      {
-        "Name": "inbox-B",
-        "Path": "C:/Temp/FileHorizon/InboxB",
-        "Pattern": "*.*",
-        "Recursive": true,
-        "DeleteAfterTransfer": true,
-        "MinStableSeconds": 2,
-        "DestinationPath": "C:/Temp/FileHorizon/OutboxB",
-        "CreateDestinationDirectories": true
+        "DeleteAfterTransfer": false
       }
     ]
   },
-  "Features": {
-    "EnableFileTransfer": false
+
+  // Remote sources live in "Ftp" and "Sftp" lists (the README's old "Sources" shape is stale).
+  "RemoteFileSources": {
+    "Ftp": [
+      {
+        "Name": "UpstreamFtp",
+        "Host": "ftp.example.com",
+        "Port": 21,
+        "RemotePath": "/drop",
+        "Pattern": "*.*",
+        "Recursive": true,
+        "MinStableSeconds": 5,
+        "Passive": true,
+        "Username": "ftpuser",
+        "PasswordSecretRef": "secrets:ftp-pass",
+        "DeleteAfterTransfer": false,
+        "Enabled": false
+      }
+    ],
+    "Sftp": [
+      {
+        "Name": "PartnerSftp",
+        "Host": "sftp.partner.net",
+        "Port": 22,
+        "RemotePath": "/inbound",
+        "Pattern": "*.*",
+        "Recursive": true,
+        "MinStableSeconds": 8,
+        "Username": "sftpuser",
+        "PasswordSecretRef": "secrets:sftp-pass",
+        "PrivateKeySecretRef": "secrets:sftp-key",
+        "PrivateKeyPassphraseSecretRef": "secrets:sftp-key-pass",
+        "HostKeyFingerprint": "SHA256:AAAA...base64...",
+        "StrictHostKey": true,
+        "DeleteAfterTransfer": false,
+        "Enabled": false
+      }
+    ]
   },
-  "Pipeline": {
-    "Role": "All"
+
+  // Local destinations use "RootPath" (the README's "BasePath" is stale; Overwrite lives on routing rules).
+  "Destinations": {
+    "Local": [
+      {
+        "Name": "OutboxA",
+        "RootPath": "C:\\data\\outboxA"
+      }
+    ],
+    "ServiceBus": [
+      // Remove this entry if you don't publish to Service Bus. The publisher activates only when a
+      // ConnectionString or FullyQualifiedNamespace is present.
+      {
+        "Name": "SbOut",
+        "EntityName": "file-events",
+        "IsTopic": false,
+        "ContentType": null,
+        "EnableGzipCompression": false,
+        "ApplicationProperties": null,
+        "ServiceBusTechnical": {
+          "ConnectionString": null,
+          "FullyQualifiedNamespace": null,
+          "ManagedIdentityClientId": null,
+          "MaxConcurrentPublishes": 4,
+          "EnableTracing": true,
+          "PublishRetryCount": 3,
+          "PublishRetryBaseDelayMs": 200,
+          "PublishRetryMaxDelayMs": 4000
+        }
+      }
+    ]
+  },
+
+  "Routing": {
+    "Rules": [
+      {
+        "Name": "local-txt",
+        "Protocol": "local",
+        "PathGlob": "**/*.txt",
+        "Destinations": ["OutboxA"],
+        "RenamePattern": "{fileName}",
+        "Overwrite": true
+      }
+    ]
+  },
+
+  "Transfer": {
+    "ChunkSizeBytes": 1048576,
+    "MaxConcurrentPerDestination": 2,
+    "Retry": {
+      "MaxAttempts": 3,
+      "BackoffBaseMs": 200,
+      "BackoffMaxMs": 10000
+    },
+    "Checksum": {
+      "Algorithm": "none"
+    }
+  },
+
+  // NEW: top-level section (not under Transfer). TtlSeconds=0 keeps processed-file markers forever.
+  // DataDirectory enables the durable file-backed store (idempotency.jsonl) when Redis is disabled;
+  // with neither Redis nor DataDirectory, markers are in-memory only and do NOT survive restarts.
+  "Idempotency": {
+    "Enabled": true,
+    "TtlSeconds": 0,
+    "DataDirectory": "C:\\ProgramData\\FileHorizon"
+  },
+
+  // When Enabled=true, this powers both the event queue (Redis Streams) and the idempotency store.
+  "Redis": {
+    "Enabled": false,
+    "ConnectionString": null,
+    "Host": "localhost",
+    "Port": 6379,
+    "StreamName": "filehorizon:file-events",
+    "ConsumerGroup": "filehorizon-workers",
+    "ConsumerNamePrefix": "fh",
+    "ReadBatchSize": 10,
+    "CreateStreamIfMissing": true,
+    "ReadBlockMilliseconds": 2000
+  },
+
+  "Telemetry": {
+    "EnableTracing": true,
+    "EnableMetrics": true,
+    "EnableLogging": true,
+    "EnablePrometheus": true,
+    "EnableOtlpExporter": false,
+    "OtlpEndpoint": null,
+    "OtlpHeaders": null,
+    "OtlpProtocol": "Grpc",
+    "TracesSampleRatio": null,
+    "ServiceName": "FileHorizon",
+    "ServiceVersion": null,
+    "DeploymentEnvironment": "dev"
   }
 }

--- a/test/FileHorizon.Application.Tests/FileBackedIdempotencyStoreTests.cs
+++ b/test/FileHorizon.Application.Tests/FileBackedIdempotencyStoreTests.cs
@@ -1,0 +1,97 @@
+using FileHorizon.Application.Infrastructure.Idempotency;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FileHorizon.Application.Tests;
+
+public class FileBackedIdempotencyStoreTests
+{
+    private static string NewStorePath()
+        => Path.Combine(Path.GetTempPath(), "fh-idemp-tests", Guid.NewGuid().ToString("N"), "idempotency.jsonl");
+
+    private static FileBackedIdempotencyStore CreateStore(string path)
+        => new(path, NullLogger<FileBackedIdempotencyStore>.Instance);
+
+    private static void Cleanup(string path)
+    {
+        try { Directory.Delete(Path.GetDirectoryName(path)!, true); } catch { }
+    }
+
+    [Fact]
+    public async Task Marks_SurviveReload()
+    {
+        var path = NewStorePath();
+        try
+        {
+            using (var store = CreateStore(path))
+            {
+                Assert.True(await store.TryMarkProcessedAsync("k1", null, CancellationToken.None));
+                Assert.True(await store.TryMarkProcessedAsync("k2", null, CancellationToken.None));
+            }
+
+            using var reloaded = CreateStore(path);
+            Assert.True(await reloaded.IsProcessedAsync("k1", CancellationToken.None));
+            Assert.True(await reloaded.IsProcessedAsync("k2", CancellationToken.None));
+            Assert.False(await reloaded.TryMarkProcessedAsync("k1", null, CancellationToken.None));
+            Assert.False(await reloaded.IsProcessedAsync("k3", CancellationToken.None));
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ExpiredEntry_IsNotHonoredAfterReload()
+    {
+        var path = NewStorePath();
+        try
+        {
+            using (var store = CreateStore(path))
+            {
+                await store.TryMarkProcessedAsync("short", TimeSpan.FromMilliseconds(30), CancellationToken.None);
+                await store.TryMarkProcessedAsync("forever", null, CancellationToken.None);
+            }
+            await Task.Delay(100);
+
+            using var reloaded = CreateStore(path);
+            Assert.False(await reloaded.IsProcessedAsync("short", CancellationToken.None));
+            Assert.True(await reloaded.IsProcessedAsync("forever", CancellationToken.None));
+            Assert.True(await reloaded.TryMarkProcessedAsync("short", null, CancellationToken.None));
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task CorruptLastLine_IsSkipped_RemainingKeysLoad()
+    {
+        var path = NewStorePath();
+        try
+        {
+            using (var store = CreateStore(path))
+            {
+                await store.TryMarkProcessedAsync("k1", null, CancellationToken.None);
+            }
+            // Simulate a torn write after a crash.
+            File.AppendAllText(path, "{\"k\":\"k2\",\"e\":nu");
+
+            using var reloaded = CreateStore(path);
+            Assert.True(await reloaded.IsProcessedAsync("k1", CancellationToken.None));
+            Assert.False(await reloaded.IsProcessedAsync("k2", CancellationToken.None));
+            // The store must still accept new marks after loading a corrupt file.
+            Assert.True(await reloaded.TryMarkProcessedAsync("k3", null, CancellationToken.None));
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ParallelMarks_SameKey_ExactlyOneWins()
+    {
+        var path = NewStorePath();
+        try
+        {
+            using var store = CreateStore(path);
+            var results = await Task.WhenAll(Enumerable.Range(0, 16)
+                .Select(_ => Task.Run(() => store.TryMarkProcessedAsync("contested", null, CancellationToken.None))));
+
+            Assert.Equal(1, results.Count(r => r));
+        }
+        finally { Cleanup(path); }
+    }
+}

--- a/test/FileHorizon.Application.Tests/FileIdentityKeyTests.cs
+++ b/test/FileHorizon.Application.Tests/FileIdentityKeyTests.cs
@@ -1,0 +1,60 @@
+using FileHorizon.Application.Common;
+using FileHorizon.Application.Models;
+
+namespace FileHorizon.Application.Tests;
+
+public class FileIdentityKeyTests
+{
+    private static FileMetadata Metadata(string path, long size, DateTimeOffset mtime)
+        => new(path, size, mtime, "none", null);
+
+    [Fact]
+    public void BuildIdempotencyKey_LocalPath_HasExpectedFormat()
+    {
+        var mtime = new DateTimeOffset(2026, 7, 20, 12, 0, 0, TimeSpan.Zero);
+        var key = FileIdentity.BuildIdempotencyKey(Metadata(@"C:\inbox\a.txt", 42, mtime));
+
+        Assert.Equal($"fh:idemp:v2:C:\\inbox\\a.txt|42|{mtime:O}", key);
+    }
+
+    [Fact]
+    public void BuildIdempotencyKey_RemotePath_HasExpectedFormat()
+    {
+        var mtime = new DateTimeOffset(2026, 7, 20, 12, 0, 0, TimeSpan.Zero);
+        var key = FileIdentity.BuildIdempotencyKey(Metadata("sftp://host:22/inbox/a.txt", 42, mtime));
+
+        Assert.StartsWith("fh:idemp:v2:sftp://host:22/inbox/a.txt|42|", key);
+    }
+
+    [Fact]
+    public void BuildIdempotencyKey_SameInstantDifferentOffsets_YieldSameKey()
+    {
+        var utc = new DateTimeOffset(2026, 7, 20, 12, 0, 0, TimeSpan.Zero);
+        var plusTwo = utc.ToOffset(TimeSpan.FromHours(2));
+
+        var keyUtc = FileIdentity.BuildIdempotencyKey(Metadata("/inbox/a.txt", 42, utc));
+        var keyPlusTwo = FileIdentity.BuildIdempotencyKey(Metadata("/inbox/a.txt", 42, plusTwo));
+
+        Assert.Equal(keyUtc, keyPlusTwo);
+    }
+
+    [Fact]
+    public void BuildIdempotencyKey_SizeChange_YieldsDifferentKey()
+    {
+        var mtime = DateTimeOffset.UtcNow;
+        var a = FileIdentity.BuildIdempotencyKey(Metadata("/inbox/a.txt", 42, mtime));
+        var b = FileIdentity.BuildIdempotencyKey(Metadata("/inbox/a.txt", 43, mtime));
+
+        Assert.NotEqual(a, b);
+    }
+
+    [Fact]
+    public void BuildIdempotencyKey_MtimeChange_YieldsDifferentKey()
+    {
+        var mtime = DateTimeOffset.UtcNow;
+        var a = FileIdentity.BuildIdempotencyKey(Metadata("/inbox/a.txt", 42, mtime));
+        var b = FileIdentity.BuildIdempotencyKey(Metadata("/inbox/a.txt", 42, mtime.AddSeconds(1)));
+
+        Assert.NotEqual(a, b);
+    }
+}

--- a/test/FileHorizon.Application.Tests/FileProcessingOrchestratorIdempotencyTests.cs
+++ b/test/FileHorizon.Application.Tests/FileProcessingOrchestratorIdempotencyTests.cs
@@ -1,0 +1,218 @@
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Common;
+using FileHorizon.Application.Configuration;
+using FileHorizon.Application.Infrastructure.FileProcessing;
+using FileHorizon.Application.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+
+namespace FileHorizon.Application.Tests;
+
+public class FileProcessingOrchestratorIdempotencyTests : IDisposable
+{
+    private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>
+        where T : class, new()
+    {
+        private readonly T _value = value;
+        public T CurrentValue => _value;
+        public T Get(string? name) => _value;
+        public IDisposable OnChange(Action<T, string?> listener) => new NoopDisposable();
+        private sealed class NoopDisposable : IDisposable { public void Dispose() { } }
+    }
+
+    private sealed class FakePublisher : IFileContentPublisher
+    {
+        public Task<Result> PublishAsync(FilePublishRequest request, CancellationToken ct)
+            => Task.FromResult(Result.Success());
+    }
+
+    private readonly string _srcFile;
+    private readonly string _destRoot;
+
+    public FileProcessingOrchestratorIdempotencyTests()
+    {
+        _srcFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        _destRoot = Path.Combine(Path.GetTempPath(), "orchestrator-idemp-tests", Guid.NewGuid().ToString("N"));
+        File.WriteAllText(_srcFile, "hello idempotency");
+    }
+
+    public void Dispose()
+    {
+        try { File.Delete(_srcFile); } catch { }
+        try { Directory.Delete(_destRoot, true); } catch { }
+    }
+
+    private FileEvent NewEvent(DateTimeOffset? mtime = null) => new(
+        Id: Guid.NewGuid().ToString("N"),
+        Metadata: new FileMetadata(_srcFile, new FileInfo(_srcFile).Length, mtime ?? new DateTimeOffset(2026, 7, 20, 12, 0, 0, TimeSpan.Zero), "none", null),
+        DiscoveredAtUtc: DateTimeOffset.UtcNow,
+        Protocol: "local",
+        DestinationPath: string.Empty,
+        DeleteAfterTransfer: false);
+
+    private FileProcessingOrchestrator CreateOrchestrator(IIdempotencyStore store, bool enabled = true, bool overwrite = true)
+    {
+        var routing = new RoutingOptions
+        {
+            Rules =
+            [
+                new RoutingRuleOptions
+                {
+                    Name = "local",
+                    Protocol = "local",
+                    PathGlob = "**/*.txt",
+                    Destinations = ["OutboxA"],
+                    Overwrite = overwrite,
+                    RenamePattern = "{fileName}"
+                }
+            ]
+        };
+        var router = new Infrastructure.Processing.SimpleFileRouter(
+            routingOptions: new StaticOptionsMonitor<RoutingOptions>(routing),
+            destinationsOptions: new StaticOptionsMonitor<DestinationsOptions>(new DestinationsOptions()),
+            logger: NullLogger<Infrastructure.Processing.SimpleFileRouter>.Instance);
+
+        var destinations = new DestinationsOptions
+        {
+            Local = [new LocalDestinationOptions { Name = "OutboxA", RootPath = _destRoot }]
+        };
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+        return new FileProcessingOrchestrator(
+            router: router,
+            readers: [new Infrastructure.Processing.LocalFileContentReader(NullLogger<Infrastructure.Processing.LocalFileContentReader>.Instance)],
+            sinks: [new Infrastructure.Processing.LocalFileSink(NullLogger<Infrastructure.Processing.LocalFileSink>.Instance)],
+            destinations: new StaticOptionsMonitor<DestinationsOptions>(destinations),
+            idempotencyOptions: new StaticOptionsMonitor<IdempotencyOptions>(new IdempotencyOptions { Enabled = enabled, TtlSeconds = 0 }),
+            remoteSources: new StaticOptionsMonitor<RemoteFileSourcesOptions>(new RemoteFileSourcesOptions()),
+            idempotencyStore: store,
+            sftpFactory: new Infrastructure.Remote.SshNetSftpClientFactory(NullLogger<Infrastructure.Remote.SshNetSftpClientFactory>.Instance),
+            secretResolver: new Infrastructure.Secrets.InMemorySecretResolver(configuration, NullLogger<Infrastructure.Secrets.InMemorySecretResolver>.Instance),
+            sftpClientLogger: NullLogger<Infrastructure.Remote.SftpRemoteFileClient>.Instance,
+            ftpClientLogger: NullLogger<Infrastructure.Remote.FtpRemoteFileClient>.Instance,
+            publisher: new FakePublisher(),
+            fileTypeDetector: new Infrastructure.Processing.ExtensionFileTypeDetector(),
+            logger: NullLogger<FileProcessingOrchestrator>.Instance);
+    }
+
+    private string DestFile => Path.Combine(_destRoot, Path.GetFileName(_srcFile));
+
+    [Fact]
+    public async Task SecondEvent_SameIdentityDifferentGuid_IsSkipped()
+    {
+        var store = new Infrastructure.Idempotency.InMemoryIdempotencyStore();
+        var orchestrator = CreateOrchestrator(store);
+
+        var first = await orchestrator.ProcessAsync(NewEvent(), CancellationToken.None);
+        Assert.True(first.IsSuccess);
+        Assert.True(File.Exists(DestFile));
+
+        // Simulate re-discovery after a restart: new GUID, same file identity.
+        File.Delete(DestFile);
+        var second = await orchestrator.ProcessAsync(NewEvent(), CancellationToken.None);
+
+        Assert.True(second.IsSuccess);
+        Assert.False(File.Exists(DestFile)); // skipped, nothing written
+    }
+
+    [Fact]
+    public async Task ChangedMtime_IsProcessedAgain()
+    {
+        var store = new Infrastructure.Idempotency.InMemoryIdempotencyStore();
+        var orchestrator = CreateOrchestrator(store);
+
+        var mtime = new DateTimeOffset(2026, 7, 20, 12, 0, 0, TimeSpan.Zero);
+        Assert.True((await orchestrator.ProcessAsync(NewEvent(mtime), CancellationToken.None)).IsSuccess);
+
+        File.Delete(DestFile);
+        Assert.True((await orchestrator.ProcessAsync(NewEvent(mtime.AddMinutes(5)), CancellationToken.None)).IsSuccess);
+
+        Assert.True(File.Exists(DestFile)); // new version transferred
+    }
+
+    [Fact]
+    public async Task FailedTransfer_DoesNotMark_RetrySucceeds()
+    {
+        var store = new Infrastructure.Idempotency.InMemoryIdempotencyStore();
+        // Overwrite=false + pre-existing destination file => LocalFileSink fails with CreateNew collision.
+        var failing = CreateOrchestrator(store, overwrite: false);
+        Directory.CreateDirectory(_destRoot);
+        File.WriteAllText(DestFile, "occupied");
+
+        var ev = NewEvent();
+        var failed = await failing.ProcessAsync(ev, CancellationToken.None);
+        Assert.True(failed.IsFailure);
+        Assert.False(await store.IsProcessedAsync(FileIdentity.BuildIdempotencyKey(ev.Metadata), CancellationToken.None));
+
+        // Clear the collision; the same identity must be retryable.
+        File.Delete(DestFile);
+        var retried = await failing.ProcessAsync(NewEvent(), CancellationToken.None);
+        Assert.True(retried.IsSuccess);
+        Assert.True(await store.IsProcessedAsync(FileIdentity.BuildIdempotencyKey(ev.Metadata), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task StoreCheckThrows_ProcessingProceeds()
+    {
+        var store = Substitute.For<IIdempotencyStore>();
+        store.IsProcessedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("store down"));
+        store.TryMarkProcessedAsync(Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        var orchestrator = CreateOrchestrator(store);
+
+        var result = await orchestrator.ProcessAsync(NewEvent(), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.True(File.Exists(DestFile)); // fail-open: transferred despite check failure
+    }
+
+    [Fact]
+    public async Task MarkThrowsAfterSuccessfulTransfer_ResultIsStillSuccess()
+    {
+        var store = Substitute.For<IIdempotencyStore>();
+        store.IsProcessedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        store.TryMarkProcessedAsync(Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("store down"));
+        var orchestrator = CreateOrchestrator(store);
+
+        var result = await orchestrator.ProcessAsync(NewEvent(), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.True(File.Exists(DestFile));
+    }
+
+    [Fact]
+    public async Task Disabled_StoreIsNeverCalled()
+    {
+        var store = Substitute.For<IIdempotencyStore>();
+        var orchestrator = CreateOrchestrator(store, enabled: false);
+
+        var result = await orchestrator.ProcessAsync(NewEvent(), CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        await store.DidNotReceive().IsProcessedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await store.DidNotReceive().TryMarkProcessedAsync(Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SuccessfulTransfer_MarksWithNullTtl_WhenTtlSecondsIsZero()
+    {
+        var store = Substitute.For<IIdempotencyStore>();
+        store.IsProcessedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        store.TryMarkProcessedAsync(Arg.Any<string>(), Arg.Any<TimeSpan?>(), Arg.Any<CancellationToken>()).Returns(true);
+        var orchestrator = CreateOrchestrator(store);
+
+        var ev = NewEvent();
+        var result = await orchestrator.ProcessAsync(ev, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        await store.Received(1).TryMarkProcessedAsync(
+            FileIdentity.BuildIdempotencyKey(ev.Metadata),
+            null,
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/test/FileHorizon.Application.Tests/IdempotencyOptionsValidatorTests.cs
+++ b/test/FileHorizon.Application.Tests/IdempotencyOptionsValidatorTests.cs
@@ -1,0 +1,43 @@
+using FileHorizon.Application.Configuration;
+
+namespace FileHorizon.Application.Tests;
+
+public class IdempotencyOptionsValidatorTests
+{
+    private static readonly IdempotencyOptionsValidator Validator = new();
+
+    [Fact]
+    public void NegativeTtl_Fails()
+    {
+        var result = Validator.Validate(null, new IdempotencyOptions { TtlSeconds = -1 });
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void ZeroTtl_Passes()
+    {
+        var result = Validator.Validate(null, new IdempotencyOptions { TtlSeconds = 0 });
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void WhitespaceDataDirectory_Fails()
+    {
+        var result = Validator.Validate(null, new IdempotencyOptions { DataDirectory = "   " });
+        Assert.True(result.Failed);
+    }
+
+    [Fact]
+    public void ValidDataDirectory_Passes()
+    {
+        var result = Validator.Validate(null, new IdempotencyOptions { DataDirectory = Path.GetTempPath() });
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void InvalidDataDirectory_Fails()
+    {
+        var result = Validator.Validate(null, new IdempotencyOptions { DataDirectory = "bad\0path" });
+        Assert.True(result.Failed);
+    }
+}

--- a/test/FileHorizon.Application.Tests/InMemoryIdempotencyStoreTests.cs
+++ b/test/FileHorizon.Application.Tests/InMemoryIdempotencyStoreTests.cs
@@ -1,0 +1,48 @@
+using FileHorizon.Application.Infrastructure.Idempotency;
+
+namespace FileHorizon.Application.Tests;
+
+public class InMemoryIdempotencyStoreTests
+{
+    [Fact]
+    public async Task TryMark_FirstCallTrue_SecondCallFalse()
+    {
+        var store = new InMemoryIdempotencyStore();
+
+        Assert.True(await store.TryMarkProcessedAsync("k1", null, CancellationToken.None));
+        Assert.False(await store.TryMarkProcessedAsync("k1", null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task IsProcessed_FalseBeforeMark_TrueAfterMark()
+    {
+        var store = new InMemoryIdempotencyStore();
+
+        Assert.False(await store.IsProcessedAsync("k1", CancellationToken.None));
+        await store.TryMarkProcessedAsync("k1", null, CancellationToken.None);
+        Assert.True(await store.IsProcessedAsync("k1", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task NullTtl_NeverExpires()
+    {
+        var store = new InMemoryIdempotencyStore();
+        await store.TryMarkProcessedAsync("k1", null, CancellationToken.None);
+
+        await Task.Delay(50);
+        Assert.True(await store.IsProcessedAsync("k1", CancellationToken.None));
+        Assert.False(await store.TryMarkProcessedAsync("k1", null, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ExpiredTtl_EntryIsNotProcessed_AndCanBeRemarked()
+    {
+        var store = new InMemoryIdempotencyStore();
+        await store.TryMarkProcessedAsync("k1", TimeSpan.FromMilliseconds(30), CancellationToken.None);
+
+        await Task.Delay(100);
+        Assert.False(await store.IsProcessedAsync("k1", CancellationToken.None));
+        Assert.True(await store.TryMarkProcessedAsync("k1", null, CancellationToken.None));
+        Assert.True(await store.IsProcessedAsync("k1", CancellationToken.None));
+    }
+}

--- a/test/FileHorizon.Application.Tests/LocalDirectoryPollerTests.cs
+++ b/test/FileHorizon.Application.Tests/LocalDirectoryPollerTests.cs
@@ -88,4 +88,43 @@ public class LocalDirectoryPollerTests
             Directory.Delete(tempRoot, true);
         }
     }
+
+    [Fact]
+    public async Task PollAsync_SizeOnlyChange_ReDispatches_UnchangedDoesNot()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "fh-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        try
+        {
+            var filePath = Path.Combine(tempRoot, "sample.txt");
+            var mtime = DateTime.UtcNow.AddSeconds(-30);
+            await File.WriteAllTextAsync(filePath, "v1");
+            File.SetLastWriteTimeUtc(filePath, mtime);
+
+            var sourcesOptions = new FileSourcesOptions
+            {
+                Sources =
+                [
+                    new() { Name = "test", Path = tempRoot, Pattern = "*.txt", Recursive = false, MinStableSeconds = 1 }
+                ]
+            };
+            var queue = new TestQueue();
+            var poller = new LocalDirectoryPoller(queue, NullLogger<LocalDirectoryPoller>.Instance, new OptionsMonitorStub<FileSourcesOptions>(sourcesOptions));
+
+            await poller.PollAsync(CancellationToken.None);
+            await poller.PollAsync(CancellationToken.None); // unchanged: no re-dispatch
+            Assert.Single(queue.TryDrain(10));
+
+            // Size-only change (mtime restored to the same value) must re-dispatch.
+            await File.WriteAllTextAsync(filePath, "v2 longer");
+            File.SetLastWriteTimeUtc(filePath, mtime);
+            await poller.PollAsync(CancellationToken.None);
+
+            Assert.Single(queue.TryDrain(10));
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, true);
+        }
+    }
 }

--- a/test/FileHorizon.Application.Tests/RemotePollerTests.cs
+++ b/test/FileHorizon.Application.Tests/RemotePollerTests.cs
@@ -116,6 +116,44 @@ public class RemotePollerTests
     }
 
     [Fact]
+    public async Task PollAsync_ChangedFile_IsReDispatchedAsNewVersion()
+    {
+        var opts = CreateOptions(new FtpSourceOptions { Name = "f1", Host = "h", Port = 21, RemotePath = "/", Pattern = "*", MinStableSeconds = 0 });
+        var queue = new TestQueue();
+        var mtime = DateTimeOffset.UtcNow.AddMinutes(-10);
+        var versions = new List<FakeRemoteFile[]> {
+            new [] { new FakeRemoteFile("/a.txt", 5, mtime) },   // poll 1: dispatched
+            new [] { new FakeRemoteFile("/a.txt", 9, mtime) },   // poll 2: size changed -> unstable, baseline reset
+            new [] { new FakeRemoteFile("/a.txt", 9, mtime) },   // poll 3: stable again -> must re-dispatch
+        };
+        int call = 0;
+        var poller = new TestRemotePoller(queue, opts, _ => new FakeRemoteClient("h", 21, ProtocolType.Ftp, versions[Math.Min(call++, versions.Count - 1)]));
+
+        await poller.PollAsync(CancellationToken.None);
+        await poller.PollAsync(CancellationToken.None);
+        await poller.PollAsync(CancellationToken.None);
+
+        var events = queue.TryDrain(10);
+        Assert.Equal(2, events.Count); // original version + changed version
+        Assert.All(events, e => Assert.EndsWith("/a.txt", e.Metadata.SourcePath));
+    }
+
+    [Fact]
+    public async Task PollAsync_UnchangedFile_IsNotReDispatched()
+    {
+        var opts = CreateOptions(new FtpSourceOptions { Name = "f1", Host = "h", Port = 21, RemotePath = "/", Pattern = "*", MinStableSeconds = 0 });
+        var queue = new TestQueue();
+        var file = new FakeRemoteFile("/a.txt", 5, DateTimeOffset.UtcNow.AddMinutes(-10));
+        var poller = new TestRemotePoller(queue, opts, _ => new FakeRemoteClient("h", 21, ProtocolType.Ftp, new[] { file }));
+
+        await poller.PollAsync(CancellationToken.None);
+        await poller.PollAsync(CancellationToken.None);
+        await poller.PollAsync(CancellationToken.None);
+
+        Assert.Single(queue.TryDrain(10));
+    }
+
+    [Fact]
     public async Task PollAsync_ConnectionFailure_TriggersBackoff()
     {
         var opts = CreateOptions(new FtpSourceOptions { Name = "f1", Host = "h", Port = 21, RemotePath = "/", Pattern = "*", MinStableSeconds = 0 });

--- a/test/FileHorizon.Application.Tests/ServiceRegistrationTests.cs
+++ b/test/FileHorizon.Application.Tests/ServiceRegistrationTests.cs
@@ -66,6 +66,49 @@ public class ServiceRegistrationTests
         return services.BuildServiceProvider();
     }
 
+    private static ServiceProvider BuildServiceProviderWithIdempotency(IdempotencyOptions idempotencyOptions)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection().Build());
+        services.AddLogging(b => b.AddDebug().AddConsole());
+        services.AddApplicationServices();
+        services.AddSingleton<IFileContentPublisher, TestNoopFileContentPublisher>();
+        services.AddSingleton<IOptions<PipelineFeaturesOptions>>(Options.Create(new PipelineFeaturesOptions { EnableLocalPoller = true }));
+        services.AddSingleton<IOptions<PollingOptions>>(Options.Create(new PollingOptions()));
+        services.AddSingleton<IOptions<RedisOptions>>(Options.Create(new RedisOptions()));
+        services.AddSingleton<IOptions<FileSourcesOptions>>(Options.Create(new FileSourcesOptions()));
+        services.AddSingleton<IOptions<DestinationsOptions>>(Options.Create(new DestinationsOptions()));
+        services.AddSingleton<IOptions<RoutingOptions>>(Options.Create(new RoutingOptions()));
+        services.AddSingleton<IOptions<TransferOptions>>(Options.Create(new TransferOptions()));
+        services.AddSingleton<IOptions<PipelineOptions>>(Options.Create(new PipelineOptions()));
+        services.AddSingleton<IOptions<IdempotencyOptions>>(Options.Create(idempotencyOptions));
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void IdempotencyStore_Should_Be_InMemory_When_Nothing_Configured()
+    {
+        using var sp = BuildServiceProvider();
+        var store = sp.GetRequiredService<IIdempotencyStore>();
+        Assert.IsType<Infrastructure.Idempotency.InMemoryIdempotencyStore>(store);
+    }
+
+    [Fact]
+    public void IdempotencyStore_Should_Be_FileBacked_When_DataDirectory_Set_And_Redis_Disabled()
+    {
+        var dataDir = Path.Combine(Path.GetTempPath(), "fh-idemp-di-tests", Guid.NewGuid().ToString("N"));
+        try
+        {
+            using var sp = BuildServiceProviderWithIdempotency(new IdempotencyOptions { Enabled = true, DataDirectory = dataDir });
+            var store = sp.GetRequiredService<IIdempotencyStore>();
+            Assert.IsType<Infrastructure.Idempotency.FileBackedIdempotencyStore>(store);
+        }
+        finally
+        {
+            try { Directory.Delete(dataDir, true); } catch { }
+        }
+    }
+
     [Fact]
     public void IFileProcessor_Should_Be_Orchestrator_By_Default()
     {


### PR DESCRIPTION
## Summary

Files left at the source (`DeleteAfterTransfer=false`) were re-copied on every restart: pollers dedup in-memory only, and the durable idempotency gate was keyed on the per-event GUID (`file:{FileEvent.Id}`), so re-discovered files never matched. On top of that, the `Idempotency` config section was never bound in the Host, so the feature was silently inert.

This PR makes "already copied" tracking durable, restart-surviving, and indefinite:

- **Identity-based key**: new `FileIdentity` helper builds `fh:idemp:v2:{SourcePath}|{SizeBytes}|{LastModifiedUtc:O}`. A modified file (new size/mtime) is a new version and is transferred again.
- **Check-before / mark-after-success**: the orchestrator checks the store before processing but writes the marker only after a successful transfer. A crash or failed transfer is retried, never permanently suppressed. Store errors fail open (bias: rare duplicate over silent loss).
- **Indefinite retention**: `TtlSeconds=0` (new default) keeps markers forever; Redis `SET NX` without `EX`; in-memory store now honors TTLs.
- **File-backed durable store**: `FileBackedIdempotencyStore` (append-only JSONL under `Idempotency:DataDirectory`) for single-node runs without Redis; tolerates a torn last line after a crash. DI selection: Redis -> file-backed -> in-memory (warning when enabled but non-durable).
- **Host fixes**: bind the `Idempotency` section (was missing, feature was a no-op) and add `IdempotencyOptionsValidator`.
- **Poller dedup fixes**: `RemotePollerBase` and `LocalDirectoryPoller` now compare size+mtime, so changed files are re-dispatched in-process too (remote previously never re-dispatched a changed file).
- **Docs**: README/architecture docs updated, including fixing stale config examples (`RootPath` vs `BasePath`, `RemoteFileSources.Ftp/Sftp` lists, actual routing rule shape, correct `Idempotency__*` env names).

## Out of scope (documented)

The Redis Streams queue still ACKs entries on read. With mark-after-success this is compensated by re-discovery of unmarked files; ACK-after-write remains planned hardening (noted in `docs/processing-architecture.md`).

## Test plan

- 27 new tests: key format, both store implementations (incl. persistence across instances, corrupt-line recovery, parallel marks), orchestrator gate (skip-same-identity, re-process-changed-mtime, failed-transfer-not-marked, fail-open, disabled-store-untouched), poller re-dispatch, DI selection, options validation.
- Full suite: 169 passed, 0 failed (3 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)