### PR TITLE
feat(storage): add Azure Blob Storage sink destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,65 @@ Future enhancements under consideration:
 - Session / scheduled messages.
 - Line/record splitting with transformation stage before publish.
 
+### Destinations: Adding Azure Blob Storage
+
+Destinations also support an Azure Blob Storage variant (`Destinations:AzureBlob`). A blob destination lets routing rules write files to a storage account container with a streaming upload (no full buffering), making it suitable for large files.
+
+Configuration (`Destinations:AzureBlob`):
+
+```json
+{
+  "Destinations": {
+    "AzureBlob": [
+      {
+        "Name": "AnalyticsBlob",
+        "ContainerName": "incoming",
+        "RootPathPrefix": "ingest/2025",
+        "AccessTier": "Hot",
+        "ContentTypeStrategy": "InferFromExtension",
+        "OverwritePolicy": "FailIfExists",
+        "BlobTechnical": {
+          "AccountName": "myaccount"
+        }
+      }
+    ]
+  },
+  "Routing": {
+    "Rules": [
+      {
+        "Name": "CsvToBlob",
+        "Protocol": "local",
+        "PathGlob": "**/*.csv",
+        "Destinations": ["AnalyticsBlob"]
+      }
+    ]
+  }
+}
+```
+
+Options:
+
+- `ContainerName` (required): target blob container (must already exist).
+- `RootPathPrefix` (optional): virtual folder prefix prepended to every blob path.
+- `AccessTier` (optional): `Hot` | `Cool` | `Cold` | `Archive`; applied per upload.
+- `ContentTypeStrategy`: `InferFromExtension` (default; falls back to `application/octet-stream`), `Provided` (requires `ContentType`), or `None`.
+- `OverwritePolicy`: `FailIfExists` (upload is rejected with `Storage.AlreadyExists` when the blob exists) or `Overwrite`. When omitted, the routing rule's `Overwrite` flag applies.
+- `BlobTechnical`: authentication and retry settings. Provide `ConnectionString` for shared-key/Azurite scenarios, or `AccountName` (optionally with `ManagedIdentityClientId`) for managed identity via `DefaultAzureCredential`. `ServiceUri` overrides `AccountName` for sovereign clouds or a custom Azurite endpoint. Transient failures (throttling, timeouts, 5xx) are retried by the Azure SDK per `MaxRetries` / `RetryBaseDelayMs` / `RetryMaxDelayMs`.
+
+Local development against Azurite:
+
+```
+Destinations__AzureBlob__0__Name=AnalyticsBlob
+Destinations__AzureBlob__0__ContainerName=incoming
+Destinations__AzureBlob__0__BlobTechnical__ConnectionString=UseDevelopmentStorage=true
+```
+
+Telemetry:
+
+- Uploads run inside a `sink.write` activity tagged with `sink.name=AzureBlob`, `blob.container`, `blob.path`, `blob.tier` and `blob.account`.
+- Metrics on the shared `FileHorizon` meter: `blob.upload.bytes`, `blob.upload.duration.ms`, `blob.upload.successes` (tagged with `tier`), and `blob.upload.failures` (tagged with `reason`).
+- Failures are translated to domain errors (`Storage.AlreadyExists`, `Storage.ContainerMissing`, `Storage.Authorization`, `Storage.UploadTransient`, `Storage.UploadError`), never raw exceptions.
+
 ---
 
 ## Service Bus Egress (File ➜ Azure Service Bus Queue/Topic)

--- a/docs/processing-architecture.md
+++ b/docs/processing-architecture.md
@@ -170,7 +170,7 @@ These remain in the roadmap and will be added once multi-destination routing is 
 | 4    | Orchestrator replaces legacy processor                                                   | Implemented | `FileProcessingOrchestrator` registered as sole `IFileProcessor`; legacy removed |
 | 5    | Idempotency (Redis / file-backed / in‑memory)                                            | Implemented | Identity key (path+size+mtime), indefinite retention, mark-after-success        |
 | 6    | Fan‑out & retries                                                                        | Planned     | Current orchestrator processes first destination only                            |
-| 7    | New sinks (SFTP, Blob, etc.)                                                             | Planned     | Only Local sink implemented; SFTP is reader-only                                 |
+| 7    | New sinks (SFTP, Blob, etc.)                                                             | Partial     | Local + Azure Blob sinks implemented; SFTP is reader-only                        |
 | 8    | Expanded telemetry (router.\*, sink failure metrics)                                     | Planned     | Metrics subset live; additional counters pending fan‑out                         |
 
 ### Current limitations
@@ -214,7 +214,7 @@ These remain in the roadmap and will be added once multi-destination routing is 
 | Archive / retention                         | No           | N/A                                           | Add post-write archive step                |
 | Service Bus ingress/egress                  | No           | N/A                                           | Implement as async bridges                 |
 | Checksum / integrity                        | No           | N/A                                           | Add optional hash compute & validation     |
-| Sink abstraction for cloud                  | No           | N/A                                           | Implement Blob/S3 sinks                    |
+| Sink abstraction for cloud                  | Partial      | `AzureBlobFileSink` via `IBlobStorageClient`  | Add S3 sink                                |
 | Extended metrics (router.\*, sink.failures) | No           | N/A                                           | Emit after fan-out                         |
 
 ---

--- a/src/FileHorizon.Application/Abstractions/IBlobStorageClient.cs
+++ b/src/FileHorizon.Application/Abstractions/IBlobStorageClient.cs
@@ -1,0 +1,13 @@
+using FileHorizon.Application.Common;
+using FileHorizon.Application.Models;
+
+namespace FileHorizon.Application.Abstractions;
+
+/// <summary>
+/// Minimal blob storage operations used by the blob sink. Abstracted so the sink can be unit tested
+/// without a live storage account.
+/// </summary>
+public interface IBlobStorageClient
+{
+    Task<Result<BlobUploadResult>> UploadAsync(BlobUploadRequest request, Stream content, CancellationToken ct);
+}

--- a/src/FileHorizon.Application/Common/Result.cs
+++ b/src/FileHorizon.Application/Common/Result.cs
@@ -71,6 +71,16 @@ public readonly record struct Error(string Code, string Message)
         public static readonly Error NegativeSize = new("Validation.NegativeSize", "File size must be >= 0");
     }
 
+    public static class Storage
+    {
+        public static Error NotConfigured(string destination) => new("Storage.NotConfigured", $"Blob destination '{destination}' is not configured");
+        public static Error AlreadyExists(string path) => new("Storage.AlreadyExists", $"Blob already exists: {path}");
+        public static Error ContainerMissing(string container) => new("Storage.ContainerMissing", $"Blob container not found: {container}");
+        public static Error Authorization(string message) => new("Storage.Authorization", message);
+        public static Error UploadTransient(string message) => new("Storage.UploadTransient", message);
+        public static Error UploadError(string message) => new("Storage.UploadError", message);
+    }
+
     public static class Messaging
     {
         public static readonly Error DestinationEmpty = new("Messaging.DestinationEmpty", "DestinationName must be provided.");

--- a/src/FileHorizon.Application/Configuration/DestinationsOptions.cs
+++ b/src/FileHorizon.Application/Configuration/DestinationsOptions.cs
@@ -7,6 +7,7 @@ public sealed class DestinationsOptions
     public List<LocalDestinationOptions> Local { get; set; } = [];
     public List<SftpDestinationOptions> Sftp { get; set; } = [];
     public List<ServiceBusDestinationOptions> ServiceBus { get; set; } = [];
+    public List<AzureBlobDestinationOptions> AzureBlob { get; set; } = [];
 }
 
 public sealed class LocalDestinationOptions
@@ -69,6 +70,54 @@ public sealed class ServiceBusDestinationOptions
     public bool EnableGzipCompression { get; set; } = false;
     
     public ServiceBusTechnicalOptions ServiceBusTechnical { get; set; } = new(); // destination specific Service Bus settings (retries, tracing, MI namespace)
+}
+
+public sealed class AzureBlobDestinationOptions
+{
+    public string Name { get; set; } = string.Empty; // logical destination name used in routing rules
+    public string ContainerName { get; set; } = string.Empty;
+    /// <summary>Optional virtual folder prefix prepended to every blob path (e.g. "ingest/2025").</summary>
+    public string? RootPathPrefix { get; set; }
+    /// <summary>Optional access tier applied on upload: Hot | Cool | Cold | Archive.</summary>
+    public string? AccessTier { get; set; }
+    /// <summary>How the blob Content-Type is determined. Default infers from the file extension.</summary>
+    public BlobContentTypeStrategy ContentTypeStrategy { get; set; } = BlobContentTypeStrategy.InferFromExtension;
+    /// <summary>Content type applied when ContentTypeStrategy is Provided.</summary>
+    public string? ContentType { get; set; }
+    /// <summary>Overwrite behavior for existing blobs. When omitted, the routing rule's Overwrite flag applies.</summary>
+    public BlobOverwritePolicy? OverwritePolicy { get; set; }
+    public AzureBlobTechnicalOptions BlobTechnical { get; set; } = new(); // destination specific storage settings (auth, retries)
+}
+
+public enum BlobContentTypeStrategy
+{
+    InferFromExtension = 0,
+    Provided = 1,
+    None = 2
+}
+
+public enum BlobOverwritePolicy
+{
+    FailIfExists = 0,
+    Overwrite = 1
+}
+
+public sealed class AzureBlobTechnicalOptions
+{
+    /// <summary>Connection string enabling the destination; if null/empty falls back to managed identity (AccountName or ServiceUri).</summary>
+    public string? ConnectionString { get; set; }
+    /// <summary>Storage account name used to build https://{AccountName}.blob.core.windows.net for managed identity auth.</summary>
+    public string? AccountName { get; set; }
+    /// <summary>Optional full blob service URI (takes precedence over AccountName; useful for Azurite or sovereign clouds).</summary>
+    public string? ServiceUri { get; set; }
+    /// <summary>Optional managed identity client id (user-assigned) if a specific identity should be used for auth.</summary>
+    public string? ManagedIdentityClientId { get; init; }
+    /// <summary>Maximum retry attempts for transient upload failures (Azure SDK retry policy). Set to 0 to disable retries.</summary>
+    public int MaxRetries { get; init; } = 3;
+    /// <summary>Base delay in milliseconds for the first retry attempt.</summary>
+    public int RetryBaseDelayMs { get; init; } = 500;
+    /// <summary>Maximum delay cap in milliseconds for exponential backoff.</summary>
+    public int RetryMaxDelayMs { get; init; } = 8000;
 }
 
 public sealed class ServiceBusTechnicalOptions

--- a/src/FileHorizon.Application/Configuration/DestinationsOptionsValidator.cs
+++ b/src/FileHorizon.Application/Configuration/DestinationsOptionsValidator.cs
@@ -12,6 +12,23 @@ public sealed class DestinationsOptionsValidator : IValidateOptions<Destinations
         "Content-Encoding" // Reserved for compression
     };
 
+    private static readonly HashSet<string> ValidAccessTiers = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Hot", "Cool", "Cold", "Archive"
+    };
+
+    private static bool IsValidContainerName(string name)
+    {
+        if (name.Length is < 3 or > 63) return false;
+        if (!char.IsAsciiLetterLower(name[0]) && !char.IsAsciiDigit(name[0])) return false;
+        if (!char.IsAsciiLetterLower(name[^1]) && !char.IsAsciiDigit(name[^1])) return false;
+        foreach (var c in name)
+        {
+            if (!char.IsAsciiLetterLower(c) && !char.IsAsciiDigit(c) && c != '-') return false;
+        }
+        return !name.Contains("--");
+    }
+
     public ValidateOptionsResult Validate(string? name, DestinationsOptions options)
     {
         if (options is null) return ValidateOptionsResult.Fail("DestinationsOptions instance is null");
@@ -83,6 +100,46 @@ public sealed class DestinationsOptionsValidator : IValidateOptions<Destinations
                     {
                         errors.Add($"{prefix}: ApplicationProperty keys cannot be null or whitespace.");
                     }
+                }
+            }
+        }
+
+        for (int i = 0; i < options.AzureBlob.Count; i++)
+        {
+            var d = options.AzureBlob[i];
+            var prefix = $"Destinations:AzureBlob[{i}]";
+            if (string.IsNullOrWhiteSpace(d.Name)) errors.Add($"{prefix}: Name must be specified.");
+            else if (!seenNames.Add(d.Name)) errors.Add($"{prefix}: Name '{d.Name}' is duplicated.");
+
+            if (string.IsNullOrWhiteSpace(d.ContainerName)) errors.Add($"{prefix}: ContainerName must be specified.");
+            else if (!IsValidContainerName(d.ContainerName)) errors.Add($"{prefix}: ContainerName '{d.ContainerName}' is invalid (3-63 chars, lowercase letters, digits and hyphens, must start and end with letter or digit).");
+
+            if (!string.IsNullOrWhiteSpace(d.AccessTier) && !ValidAccessTiers.Contains(d.AccessTier))
+                errors.Add($"{prefix}: AccessTier '{d.AccessTier}' is invalid. Valid values: Hot, Cool, Cold, Archive.");
+
+            if (d.ContentTypeStrategy == BlobContentTypeStrategy.Provided && string.IsNullOrWhiteSpace(d.ContentType))
+                errors.Add($"{prefix}: ContentType must be specified when ContentTypeStrategy is Provided.");
+
+            if (d.BlobTechnical is null)
+            {
+                errors.Add($"{prefix}: BlobTechnical must be configured.");
+            }
+            else
+            {
+                var hasConnectionString = !string.IsNullOrWhiteSpace(d.BlobTechnical.ConnectionString);
+                var hasAccount = !string.IsNullOrWhiteSpace(d.BlobTechnical.AccountName);
+                var hasServiceUri = !string.IsNullOrWhiteSpace(d.BlobTechnical.ServiceUri);
+                if (!hasConnectionString && !hasAccount && !hasServiceUri)
+                {
+                    errors.Add($"{prefix}: Either BlobTechnical.ConnectionString, BlobTechnical.AccountName or BlobTechnical.ServiceUri must be specified.");
+                }
+                if (hasServiceUri && !Uri.TryCreate(d.BlobTechnical.ServiceUri, UriKind.Absolute, out _))
+                {
+                    errors.Add($"{prefix}: BlobTechnical.ServiceUri is not a valid absolute URI.");
+                }
+                if (d.BlobTechnical.MaxRetries < 0)
+                {
+                    errors.Add($"{prefix}: BlobTechnical.MaxRetries must be >= 0.");
                 }
             }
         }

--- a/src/FileHorizon.Application/FileHorizon.Application.csproj
+++ b/src/FileHorizon.Application/FileHorizon.Application.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="FluentFTP" Version="54.2.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.9" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />

--- a/src/FileHorizon.Application/Infrastructure/FileProcessing/FileProcessingOrchestrator.cs
+++ b/src/FileHorizon.Application/Infrastructure/FileProcessing/FileProcessingOrchestrator.cs
@@ -206,11 +206,42 @@ public sealed class FileProcessingOrchestrator(
         return Result.Success();
     }
 
+    private async Task<Result> ProcessAzureBlobAsync(FileEvent fileEvent, DestinationPlan plan, Stream stream, CancellationToken ct)
+    {
+        var destination = _destinations.CurrentValue.AzureBlob
+            .FirstOrDefault(x => string.Equals(x.Name, plan.DestinationName, StringComparison.OrdinalIgnoreCase));
+        if (destination is null)
+        {
+            _logger.LogWarning("Unknown Azure Blob destination {Dest}", plan.DestinationName);
+            return Result.Failure(Error.Validation.Invalid($"Unknown destination '{plan.DestinationName}'"));
+        }
+        var targetRef = new FileReference(
+            Scheme: Infrastructure.Processing.AzureBlobFileSink.Scheme,
+            Host: null,
+            Port: null,
+            Path: plan.TargetPath,
+            SourceName: plan.DestinationName);
+        var sink = _sinks.FirstOrDefault(s => string.Equals(s.Name, Infrastructure.Processing.AzureBlobFileSink.SinkName, StringComparison.OrdinalIgnoreCase));
+        if (sink is null)
+        {
+            return Result.Failure(Error.Unspecified("Sink.AzureBlobMissing", "Azure Blob sink not registered"));
+        }
+        var write = await sink.WriteAsync(targetRef, stream, plan.Options, ct).ConfigureAwait(false);
+        if (write.IsFailure)
+        {
+            return write;
+        }
+        await stream.DisposeAsync().ConfigureAwait(false);
+        await DeleteSourceIfRequestedAsync(fileEvent, ct).ConfigureAwait(false);
+        return Result.Success();
+    }
+
     private Task<Result> DispatchDestinationAsync(FileEvent fileEvent, DestinationPlan plan, Stream stream, CancellationToken ct) =>
         plan.Kind switch
         {
             Models.DestinationKind.ServiceBus => ProcessServiceBusAsync(fileEvent, plan, stream, ct),
             Models.DestinationKind.Local => ProcessLocalAsync(fileEvent, plan, stream, ct),
+            Models.DestinationKind.AzureBlob => ProcessAzureBlobAsync(fileEvent, plan, stream, ct),
             Models.DestinationKind.Sftp => Task.FromResult(Result.Failure(Error.Unspecified("Destination.SftpUnsupported", "Sftp destination handling not implemented"))),
             _ => Task.FromResult(Result.Failure(Error.Unspecified("Destination.UnknownKind", $"Unhandled destination kind {plan.Kind}")))
         };

--- a/src/FileHorizon.Application/Infrastructure/Processing/AzureBlobFileSink.cs
+++ b/src/FileHorizon.Application/Infrastructure/Processing/AzureBlobFileSink.cs
@@ -1,0 +1,99 @@
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Common;
+using FileHorizon.Application.Common.Telemetry;
+using FileHorizon.Application.Configuration;
+using FileHorizon.Application.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
+
+namespace FileHorizon.Application.Infrastructure.Processing;
+
+/// <summary>
+/// Sink writing files to Azure Blob Storage. Resolves the destination options by logical name
+/// (carried on <see cref="FileReference.SourceName"/>), composes the blob path from the configured
+/// prefix, determines content type per strategy and delegates the upload to <see cref="IBlobStorageClient"/>.
+/// </summary>
+public sealed class AzureBlobFileSink(
+    ILogger<AzureBlobFileSink> logger,
+    IBlobStorageClient blobClient,
+    IOptionsMonitor<DestinationsOptions> destinations,
+    IFileTypeDetector fileTypeDetector) : IFileSink
+{
+    public const string SinkName = "AzureBlob";
+    public const string Scheme = "azure-blob";
+
+    private readonly ILogger<AzureBlobFileSink> _logger = logger;
+    private readonly IBlobStorageClient _blobClient = blobClient;
+    private readonly IOptionsMonitor<DestinationsOptions> _destinations = destinations;
+    private readonly IFileTypeDetector _fileTypeDetector = fileTypeDetector;
+
+    public string Name => SinkName;
+
+    public async Task<Result> WriteAsync(FileReference target, Stream content, FileWriteOptions options, CancellationToken ct)
+    {
+        if (!string.Equals(target.Scheme, Scheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return Result.Failure(Error.Validation.Invalid($"AzureBlobFileSink received non-blob scheme '{target.Scheme}'"));
+        }
+        var destination = _destinations.CurrentValue.AzureBlob
+            .FirstOrDefault(d => string.Equals(d.Name, target.SourceName, StringComparison.OrdinalIgnoreCase));
+        if (destination is null)
+        {
+            return Result.Failure(Error.Storage.NotConfigured(target.SourceName ?? "<unknown>"));
+        }
+
+        var blobPath = ComposeBlobPath(destination.RootPathPrefix, target.Path);
+        var contentType = ResolveContentType(destination, blobPath);
+        var overwrite = destination.OverwritePolicy switch
+        {
+            BlobOverwritePolicy.Overwrite => true,
+            BlobOverwritePolicy.FailIfExists => false,
+            _ => options?.Overwrite == true
+        };
+
+        using var activity = TelemetryInstrumentation.ActivitySource.StartActivity("sink.write", ActivityKind.Internal);
+        activity?.SetTag("sink.name", Name);
+        activity?.SetTag("blob.container", destination.ContainerName);
+        activity?.SetTag("blob.path", blobPath);
+        activity?.SetTag("blob.tier", destination.AccessTier);
+
+        var request = new BlobUploadRequest(
+            DestinationName: destination.Name,
+            ContainerName: destination.ContainerName,
+            BlobPath: blobPath,
+            ContentType: contentType,
+            Overwrite: overwrite,
+            AccessTier: destination.AccessTier);
+        var upload = await _blobClient.UploadAsync(request, content, ct).ConfigureAwait(false);
+        if (upload.IsFailure)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, upload.Error.Code);
+            return Result.Failure(upload.Error);
+        }
+        var result = upload.Value!;
+        activity?.SetTag("blob.account", result.AccountName);
+        activity?.SetStatus(ActivityStatusCode.Ok);
+        TelemetryInstrumentation.BytesCopied.Add(result.BytesWritten);
+        _logger.LogInformation("Wrote blob {BlobUri} ({Bytes} bytes) for destination {Destination}",
+            result.BlobUri, result.BytesWritten, destination.Name);
+        return Result.Success();
+    }
+
+    private string? ResolveContentType(AzureBlobDestinationOptions destination, string blobPath) =>
+        destination.ContentTypeStrategy switch
+        {
+            BlobContentTypeStrategy.Provided => destination.ContentType,
+            BlobContentTypeStrategy.None => null,
+            _ => _fileTypeDetector.Detect(blobPath) ?? "application/octet-stream"
+        };
+
+    /// <summary>Joins the configured prefix and target path into a normalized, relative blob path.</summary>
+    internal static string ComposeBlobPath(string? prefix, string path)
+    {
+        var normalized = path.Replace('\\', '/').TrimStart('/');
+        if (string.IsNullOrWhiteSpace(prefix)) return normalized;
+        var normalizedPrefix = prefix.Replace('\\', '/').Trim('/');
+        return normalizedPrefix.Length == 0 ? normalized : $"{normalizedPrefix}/{normalized}";
+    }
+}

--- a/src/FileHorizon.Application/Infrastructure/Processing/SimpleFileRouter.cs
+++ b/src/FileHorizon.Application/Infrastructure/Processing/SimpleFileRouter.cs
@@ -63,6 +63,7 @@ public sealed class SimpleFileRouter(
         if (_destinationsOptions.CurrentValue.Local.Any(l => string.Equals(l.Name, destinationName, StringComparison.OrdinalIgnoreCase))) return DestinationKind.Local;
         if (_destinationsOptions.CurrentValue.Sftp.Any(l => string.Equals(l.Name, destinationName, StringComparison.OrdinalIgnoreCase))) return DestinationKind.Sftp;
         if (_destinationsOptions.CurrentValue.ServiceBus.Any(l => string.Equals(l.Name, destinationName, StringComparison.OrdinalIgnoreCase))) return DestinationKind.ServiceBus;
+        if (_destinationsOptions.CurrentValue.AzureBlob.Any(l => string.Equals(l.Name, destinationName, StringComparison.OrdinalIgnoreCase))) return DestinationKind.AzureBlob;
         return DestinationKind.Local; // default fallback
     }
 

--- a/src/FileHorizon.Application/Infrastructure/Storage/AzureBlobStorageClient.cs
+++ b/src/FileHorizon.Application/Infrastructure/Storage/AzureBlobStorageClient.cs
@@ -1,0 +1,211 @@
+using Azure;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Common;
+using FileHorizon.Application.Common.Telemetry;
+using FileHorizon.Application.Configuration;
+using FileHorizon.Application.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace FileHorizon.Application.Infrastructure.Storage;
+
+/// <summary>
+/// Azure Blob Storage implementation of <see cref="IBlobStorageClient"/>. Streams content to block blobs
+/// (no full buffering) and relies on the Azure SDK retry policy for transient failures, configured per
+/// destination via <see cref="AzureBlobTechnicalOptions"/>.
+/// </summary>
+public sealed class AzureBlobStorageClient(
+    ILogger<AzureBlobStorageClient> logger,
+    IOptionsMonitor<DestinationsOptions>? destinations = null) : IBlobStorageClient
+{
+    private readonly ILogger<AzureBlobStorageClient> _logger = logger;
+    private readonly IOptionsMonitor<DestinationsOptions>? _destinations = destinations; // may be null in isolated unit tests
+    private readonly ConcurrentDictionary<string, BlobServiceClient> _clients = new(StringComparer.OrdinalIgnoreCase);
+
+    private static readonly Counter<long> _uploadBytes = TelemetryInstrumentation.Meter.CreateCounter<long>("blob.upload.bytes", unit: "bytes", description: "Total bytes uploaded to blob storage");
+    private static readonly Counter<long> _uploadSuccesses = TelemetryInstrumentation.Meter.CreateCounter<long>("blob.upload.successes", description: "Number of successful blob uploads");
+    private static readonly Counter<long> _uploadFailures = TelemetryInstrumentation.Meter.CreateCounter<long>("blob.upload.failures", description: "Number of failed blob uploads");
+    private static readonly Histogram<double> _uploadDurationMs = TelemetryInstrumentation.Meter.CreateHistogram<double>("blob.upload.duration.ms", unit: "ms", description: "Blob upload duration in milliseconds");
+
+    public async Task<Result<BlobUploadResult>> UploadAsync(BlobUploadRequest request, Stream content, CancellationToken ct)
+    {
+        var destination = _destinations?.CurrentValue.AzureBlob
+            .FirstOrDefault(d => string.Equals(d.Name, request.DestinationName, StringComparison.OrdinalIgnoreCase));
+        if (destination is null)
+        {
+            return Result<BlobUploadResult>.Failure(Error.Storage.NotConfigured(request.DestinationName));
+        }
+        var tech = destination.BlobTechnical ?? new AzureBlobTechnicalOptions();
+        var service = GetOrCreateClient(tech);
+        if (service is null)
+        {
+            return Result<BlobUploadResult>.Failure(Error.Storage.NotConfigured(
+                $"{request.DestinationName} (no ConnectionString, AccountName or ServiceUri)"));
+        }
+
+        var container = service.GetBlobContainerClient(request.ContainerName);
+        var blob = container.GetBlobClient(request.BlobPath);
+        var uploadOptions = new BlobUploadOptions();
+        if (!string.IsNullOrWhiteSpace(request.ContentType))
+        {
+            uploadOptions.HttpHeaders = new BlobHttpHeaders { ContentType = request.ContentType };
+        }
+        if (!string.IsNullOrWhiteSpace(request.AccessTier))
+        {
+            uploadOptions.AccessTier = new AccessTier(request.AccessTier);
+        }
+        if (!request.Overwrite)
+        {
+            // If-None-Match: * makes the service reject the upload when the blob already exists.
+            uploadOptions.Conditions = new BlobRequestConditions { IfNoneMatch = ETag.All };
+        }
+
+        var destinationTag = new KeyValuePair<string, object?>("destination", request.DestinationName);
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var counting = new CountingReadStream(content);
+            await blob.UploadAsync(counting, uploadOptions, ct).ConfigureAwait(false);
+            sw.Stop();
+            _uploadBytes.Add(counting.BytesRead, destinationTag);
+            _uploadSuccesses.Add(1, destinationTag, new KeyValuePair<string, object?>("tier", request.AccessTier ?? "default"));
+            _uploadDurationMs.Record(sw.Elapsed.TotalMilliseconds, destinationTag);
+            _logger.LogDebug("Uploaded blob {Container}/{Path} ({Bytes} bytes) to destination {Destination}",
+                request.ContainerName, request.BlobPath, counting.BytesRead, request.DestinationName);
+            return Result<BlobUploadResult>.Success(new BlobUploadResult(
+                AccountName: blob.AccountName,
+                ContainerName: request.ContainerName,
+                BlobPath: request.BlobPath,
+                BlobUri: blob.Uri,
+                BytesWritten: counting.BytesRead));
+        }
+        catch (RequestFailedException rfe)
+        {
+            sw.Stop();
+            var error = MapError(rfe, request);
+            _uploadFailures.Add(1, destinationTag, new KeyValuePair<string, object?>("reason", error.Code));
+            _logger.LogError(rfe, "Failed uploading blob {Container}/{Path} to destination {Destination}: {Code}",
+                request.ContainerName, request.BlobPath, request.DestinationName, error.Code);
+            return Result<BlobUploadResult>.Failure(error);
+        }
+        catch (Azure.Identity.AuthenticationFailedException afe)
+        {
+            sw.Stop();
+            _uploadFailures.Add(1, destinationTag, new KeyValuePair<string, object?>("reason", "Storage.Authorization"));
+            _logger.LogError(afe, "Authentication failed uploading blob {Container}/{Path} to destination {Destination}",
+                request.ContainerName, request.BlobPath, request.DestinationName);
+            return Result<BlobUploadResult>.Failure(Error.Storage.Authorization(FirstLine(afe.Message)));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            _uploadFailures.Add(1, destinationTag, new KeyValuePair<string, object?>("reason", "Storage.UploadError"));
+            _logger.LogError(ex, "Unexpected error uploading blob {Container}/{Path} to destination {Destination}",
+                request.ContainerName, request.BlobPath, request.DestinationName);
+            return Result<BlobUploadResult>.Failure(Error.Storage.UploadError(FirstLine(ex.Message)));
+        }
+    }
+
+    /// <summary>Translates Azure SDK request failures into domain errors, classifying transient vs permanent.</summary>
+    internal static Error MapError(RequestFailedException ex, BlobUploadRequest request)
+    {
+        if (string.Equals(ex.ErrorCode, BlobErrorCode.BlobAlreadyExists.ToString(), StringComparison.OrdinalIgnoreCase)
+            || string.Equals(ex.ErrorCode, BlobErrorCode.ConditionNotMet.ToString(), StringComparison.OrdinalIgnoreCase))
+        {
+            return Error.Storage.AlreadyExists($"{request.ContainerName}/{request.BlobPath}");
+        }
+        if (string.Equals(ex.ErrorCode, BlobErrorCode.ContainerNotFound.ToString(), StringComparison.OrdinalIgnoreCase))
+        {
+            return Error.Storage.ContainerMissing(request.ContainerName);
+        }
+        return ex.Status switch
+        {
+            401 or 403 => Error.Storage.Authorization(FirstLine(ex.Message)),
+            408 or 429 or 500 or 502 or 503 or 504 => Error.Storage.UploadTransient(FirstLine(ex.Message)),
+            _ => Error.Storage.UploadError(FirstLine(ex.Message))
+        };
+    }
+
+    // Error messages are trimmed to their first line so response headers/URLs never leak into logs or results.
+    private static string FirstLine(string message)
+    {
+        var idx = message.IndexOfAny(['\r', '\n']);
+        return idx < 0 ? message : message[..idx];
+    }
+
+    private BlobServiceClient? GetOrCreateClient(AzureBlobTechnicalOptions tech)
+    {
+        // Prefer connection string
+        if (!string.IsNullOrWhiteSpace(tech.ConnectionString))
+        {
+            return _clients.GetOrAdd("cs:" + tech.ConnectionString, _ => new BlobServiceClient(tech.ConnectionString, CreateClientOptions(tech)));
+        }
+        // Managed identity path via explicit service URI or account name
+        var serviceUri = !string.IsNullOrWhiteSpace(tech.ServiceUri)
+            ? tech.ServiceUri
+            : !string.IsNullOrWhiteSpace(tech.AccountName)
+                ? $"https://{tech.AccountName}.blob.core.windows.net"
+                : null;
+        if (serviceUri is null) return null;
+        return _clients.GetOrAdd("mi:" + serviceUri, _ =>
+        {
+            Azure.Core.TokenCredential credential = string.IsNullOrWhiteSpace(tech.ManagedIdentityClientId)
+                ? new Azure.Identity.DefaultAzureCredential()
+                : new Azure.Identity.DefaultAzureCredential(new Azure.Identity.DefaultAzureCredentialOptions { ManagedIdentityClientId = tech.ManagedIdentityClientId });
+            return new BlobServiceClient(new Uri(serviceUri), credential, CreateClientOptions(tech));
+        });
+    }
+
+    private static BlobClientOptions CreateClientOptions(AzureBlobTechnicalOptions tech)
+    {
+        var options = new BlobClientOptions();
+        options.Retry.MaxRetries = Math.Max(0, tech.MaxRetries);
+        options.Retry.Delay = TimeSpan.FromMilliseconds(Math.Max(0, tech.RetryBaseDelayMs));
+        options.Retry.MaxDelay = TimeSpan.FromMilliseconds(Math.Max(tech.RetryBaseDelayMs, tech.RetryMaxDelayMs));
+        options.Retry.Mode = Azure.Core.RetryMode.Exponential;
+        return options;
+    }
+
+    /// <summary>Counts bytes read so upload size can be reported without requiring a seekable stream. Does not own the inner stream.</summary>
+    private sealed class CountingReadStream(Stream inner) : Stream
+    {
+        public long BytesRead { get; private set; }
+
+        public override bool CanRead => inner.CanRead;
+        public override bool CanSeek => inner.CanSeek;
+        public override bool CanWrite => false;
+        public override long Length => inner.Length;
+        public override long Position { get => inner.Position; set => inner.Position = value; }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = inner.Read(buffer, offset, count);
+            BytesRead += read;
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = await inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            BytesRead += read;
+            return read;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override long Seek(long offset, SeekOrigin origin) => inner.Seek(offset, origin);
+        public override void Flush() { }
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}

--- a/src/FileHorizon.Application/Models/BlobUpload.cs
+++ b/src/FileHorizon.Application/Models/BlobUpload.cs
@@ -1,0 +1,18 @@
+namespace FileHorizon.Application.Models;
+
+/// <summary>Fully resolved upload instruction handed to <see cref="Abstractions.IBlobStorageClient"/>.</summary>
+public sealed record BlobUploadRequest(
+    string DestinationName,
+    string ContainerName,
+    string BlobPath,
+    string? ContentType,
+    bool Overwrite,
+    string? AccessTier);
+
+/// <summary>Reference to the artifact produced by a successful blob upload.</summary>
+public sealed record BlobUploadResult(
+    string AccountName,
+    string ContainerName,
+    string BlobPath,
+    Uri BlobUri,
+    long BytesWritten);

--- a/src/FileHorizon.Application/Models/DestinationPlan.cs
+++ b/src/FileHorizon.Application/Models/DestinationPlan.cs
@@ -4,7 +4,8 @@ public enum DestinationKind
 {
     Local = 0,
     Sftp = 1,
-    ServiceBus = 2
+    ServiceBus = 2,
+    AzureBlob = 3
 }
 
 public sealed record DestinationPlan(

--- a/src/FileHorizon.Application/ServiceCollectionExtensions.cs
+++ b/src/FileHorizon.Application/ServiceCollectionExtensions.cs
@@ -25,6 +25,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<Abstractions.IFileContentReader, Infrastructure.Processing.LocalFileContentReader>();
         services.AddSingleton<Abstractions.IFileContentReader, Infrastructure.Processing.SftpFileContentReader>();
         services.AddSingleton<Abstractions.IFileSink, Infrastructure.Processing.LocalFileSink>();
+        services.AddSingleton<Abstractions.IFileSink, Infrastructure.Processing.AzureBlobFileSink>();
+        // Blob client is inert until an AzureBlob destination is configured; connections are created lazily per destination.
+        services.AddSingleton<Abstractions.IBlobStorageClient, Infrastructure.Storage.AzureBlobStorageClient>();
         services.AddSingleton<Abstractions.IFileRouter, Infrastructure.Processing.SimpleFileRouter>();
         // File type detection: keep raw extension detector + composite for future sniffers
         services.AddSingleton<Infrastructure.Processing.ExtensionFileTypeDetector>();

--- a/src/FileHorizon.Application/packages.lock.json
+++ b/src/FileHorizon.Application/packages.lock.json
@@ -22,6 +22,16 @@
           "Microsoft.Azure.Amqp": "2.7.0"
         }
       },
+      "Azure.Storage.Blobs": {
+        "type": "Direct",
+        "requested": "[12.29.1, )",
+        "resolved": "12.29.1",
+        "contentHash": "pWh7xZBto8YcwiO853AB3uijTfVqs9PDte0Bu9/Zd8O9nwKiitWm0Jej1vsNkmYUzeG1552f8vJPjmtW30pBUQ==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Common": "12.28.0"
+        }
+      },
       "FluentFTP": {
         "type": "Direct",
         "requested": "[54.2.0, )",
@@ -57,15 +67,15 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.53.0",
-        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "resolved": "1.55.0",
+        "contentHash": "c7femvYS/xEUrLP1sNZN+DoQZmx3X+G3ZXtOOz0RL/7cGMCM3JVqepVmRd3AwM4IK8AtTGS4GOigCO+d/zaSsQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
           "Microsoft.Identity.Client": "4.83.1",
           "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
-          "System.ClientModel": "1.10.0",
+          "System.ClientModel": "1.11.0",
           "System.Diagnostics.DiagnosticSource": "10.0.3",
           "System.Memory.Data": "10.0.3",
           "System.Text.Encodings.Web": "10.0.3",
@@ -80,6 +90,15 @@
           "Microsoft.Azure.Amqp": "2.6.7",
           "System.Memory": "4.5.4",
           "System.Memory.Data": "1.0.2"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.28.0",
+        "contentHash": "5l8YhNrks38zKLGFW2BBFLwieyamH/xauABSASsdpZv79G0f+n2n22IjkRmUqCmALSupkwRHh2LOhbW3yj5Qgw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "System.IO.Hashing": "10.0.3"
         }
       },
       "BouncyCastle.Cryptography": {
@@ -197,8 +216,8 @@
       },
       "System.ClientModel": {
         "type": "Transitive",
-        "resolved": "1.10.0",
-        "contentHash": "lBEWs54F5Y5pZ9hC+8z4S/X76957ex+DPk7WecRHlbIHtrPfbRMMlOgI3iDn4Jpb3bSxvBnKaaHoD59auFjlBA==",
+        "resolved": "1.11.0",
+        "contentHash": "1Wl32zh7TbvN+HAO8NqDuaN0Ao2Qu/0j0NJSrXGDtpUQsTXQYJ3C6hd9/Ds2IrgP4agMQYFoXB35GZfC21ByHw==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
@@ -215,8 +234,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
       },
       "System.IO.Pipelines": {
         "type": "Transitive",

--- a/src/FileHorizon.Host/packages.lock.json
+++ b/src/FileHorizon.Host/packages.lock.json
@@ -71,15 +71,15 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.53.0",
-        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "resolved": "1.55.0",
+        "contentHash": "c7femvYS/xEUrLP1sNZN+DoQZmx3X+G3ZXtOOz0RL/7cGMCM3JVqepVmRd3AwM4IK8AtTGS4GOigCO+d/zaSsQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
           "Microsoft.Identity.Client": "4.83.1",
           "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
-          "System.ClientModel": "1.10.0",
+          "System.ClientModel": "1.11.0",
           "System.Diagnostics.DiagnosticSource": "10.0.3",
           "System.Memory.Data": "10.0.3",
           "System.Text.Encodings.Web": "10.0.3",
@@ -112,6 +112,24 @@
           "Azure.Core": "1.46.2",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.7.0"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "Transitive",
+        "resolved": "12.29.1",
+        "contentHash": "pWh7xZBto8YcwiO853AB3uijTfVqs9PDte0Bu9/Zd8O9nwKiitWm0Jej1vsNkmYUzeG1552f8vJPjmtW30pBUQ==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Common": "12.28.0"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.28.0",
+        "contentHash": "5l8YhNrks38zKLGFW2BBFLwieyamH/xauABSASsdpZv79G0f+n2n22IjkRmUqCmALSupkwRHh2LOhbW3yj5Qgw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "System.IO.Hashing": "10.0.3"
         }
       },
       "BouncyCastle.Cryptography": {
@@ -347,8 +365,8 @@
       },
       "System.ClientModel": {
         "type": "Transitive",
-        "resolved": "1.10.0",
-        "contentHash": "lBEWs54F5Y5pZ9hC+8z4S/X76957ex+DPk7WecRHlbIHtrPfbRMMlOgI3iDn4Jpb3bSxvBnKaaHoD59auFjlBA==",
+        "resolved": "1.11.0",
+        "contentHash": "1Wl32zh7TbvN+HAO8NqDuaN0Ao2Qu/0j0NJSrXGDtpUQsTXQYJ3C6hd9/Ds2IrgP4agMQYFoXB35GZfC21ByHw==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
@@ -365,8 +383,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
@@ -415,6 +433,7 @@
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
           "Azure.Messaging.ServiceBus": "[7.20.1, )",
+          "Azure.Storage.Blobs": "[12.29.1, )",
           "FluentFTP": "[54.2.0, )",
           "Microsoft.Extensions.FileSystemGlobbing": "[10.0.9, )",
           "SSH.NET": "[2025.1.0, )",

--- a/test/FileHorizon.Application.Tests/AzureBlobDestinationRoutingTests.cs
+++ b/test/FileHorizon.Application.Tests/AzureBlobDestinationRoutingTests.cs
@@ -1,0 +1,131 @@
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Common;
+using FileHorizon.Application.Configuration;
+using FileHorizon.Application.Infrastructure.FileProcessing;
+using FileHorizon.Application.Infrastructure.Processing;
+using FileHorizon.Application.Infrastructure.Remote;
+using FileHorizon.Application.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace FileHorizon.Application.Tests;
+
+public class AzureBlobDestinationRoutingTests
+{
+    private static IOptionsMonitor<RoutingOptions> RoutingOptions(params RoutingRuleOptions[] rules)
+    {
+        var ro = new RoutingOptions { Rules = [.. rules] };
+        var monitor = Substitute.For<IOptionsMonitor<RoutingOptions>>();
+        monitor.CurrentValue.Returns(ro);
+        return monitor;
+    }
+
+    private static IOptionsMonitor<DestinationsOptions> DestinationsOptions(params AzureBlobDestinationOptions[] azureBlob)
+    {
+        var d = new DestinationsOptions { AzureBlob = [.. azureBlob] };
+        var monitor = Substitute.For<IOptionsMonitor<DestinationsOptions>>();
+        monitor.CurrentValue.Returns(d);
+        return monitor;
+    }
+
+    private static AzureBlobDestinationOptions BlobDestination(string name = "analytics-blob") => new()
+    {
+        Name = name,
+        ContainerName = "incoming",
+        BlobTechnical = new AzureBlobTechnicalOptions { AccountName = "myaccount" }
+    };
+
+    [Fact]
+    public async Task Router_Resolves_AzureBlob_DestinationKind()
+    {
+        var routing = RoutingOptions(new RoutingRuleOptions
+        {
+            Name = "blobRule",
+            Protocol = "local",
+            PathGlob = "**/*.txt",
+            Destinations = ["analytics-blob"]
+        });
+        var destinations = DestinationsOptions(BlobDestination());
+        var router = new SimpleFileRouter(routing, destinations, Substitute.For<ILogger<SimpleFileRouter>>());
+        var fe = new FileEvent(
+            Id: "id1",
+            Metadata: new FileMetadata(SourcePath: "C:/data/in/file1.txt", SizeBytes: 10, LastModifiedUtc: DateTimeOffset.UtcNow, HashAlgorithm: "MD5", Checksum: null),
+            DiscoveredAtUtc: DateTimeOffset.UtcNow,
+            Protocol: "local",
+            DestinationPath: "C:/data/out/file1.txt",
+            DeleteAfterTransfer: false);
+        var result = await router.RouteAsync(fe, CancellationToken.None);
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Value!);
+        Assert.Equal(DestinationKind.AzureBlob, result.Value![0].Kind);
+    }
+
+    private sealed class FakeBlobSink : IFileSink
+    {
+        public FileReference? LastTarget { get; private set; }
+        public string Name => AzureBlobFileSink.SinkName;
+        public Task<Result> WriteAsync(FileReference target, Stream content, FileWriteOptions options, CancellationToken ct)
+        {
+            LastTarget = target;
+            return Task.FromResult(Result.Success());
+        }
+    }
+
+    [Fact]
+    public async Task Orchestrator_Dispatches_To_BlobSink_For_AzureBlob_Destination()
+    {
+        var routing = RoutingOptions(new RoutingRuleOptions
+        {
+            Name = "blobRule",
+            Protocol = "local",
+            PathGlob = "**/*.log",
+            Destinations = ["analytics-blob"]
+        });
+        var destinations = DestinationsOptions(BlobDestination());
+        var router = new SimpleFileRouter(routing, destinations, Substitute.For<ILogger<SimpleFileRouter>>());
+
+        var reader = Substitute.For<IFileContentReader>();
+        reader.OpenReadAsync(Arg.Any<FileReference>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(Result<Stream>.Success(new MemoryStream(System.Text.Encoding.UTF8.GetBytes("hello")))));
+
+        var blobSink = new FakeBlobSink();
+        var idempStore = Substitute.For<IIdempotencyStore>();
+        var remoteSources = Substitute.For<IOptionsMonitor<RemoteFileSourcesOptions>>();
+        remoteSources.CurrentValue.Returns(new RemoteFileSourcesOptions());
+        var idempOpts = Substitute.For<IOptionsMonitor<IdempotencyOptions>>();
+        idempOpts.CurrentValue.Returns(new IdempotencyOptions { Enabled = false });
+        var publisher = Substitute.For<IFileContentPublisher>();
+        var orchestrator = new FileProcessingOrchestrator(
+            router,
+            [reader],
+            [blobSink],
+            destinations,
+            idempOpts,
+            remoteSources,
+            idempStore,
+            Substitute.For<ISftpClientFactory>(),
+            Substitute.For<ISecretResolver>(),
+            Substitute.For<ILogger<SftpRemoteFileClient>>(),
+            Substitute.For<ILogger<FtpRemoteFileClient>>(),
+            publisher,
+            new ExtensionFileTypeDetector(),
+            Substitute.For<ILogger<FileProcessingOrchestrator>>());
+        var fe = new FileEvent(
+            Id: "id2",
+            Metadata: new FileMetadata(SourcePath: "C:/data/in/app.log", SizeBytes: 5, LastModifiedUtc: DateTimeOffset.UtcNow, HashAlgorithm: "MD5", Checksum: null),
+            DiscoveredAtUtc: DateTimeOffset.UtcNow,
+            Protocol: "local",
+            DestinationPath: "C:/data/out/app.log",
+            DeleteAfterTransfer: false);
+
+        var result = await orchestrator.ProcessAsync(fe, CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        Assert.NotNull(blobSink.LastTarget);
+        Assert.Equal(AzureBlobFileSink.Scheme, blobSink.LastTarget!.Scheme);
+        Assert.Equal("analytics-blob", blobSink.LastTarget.SourceName);
+        Assert.Equal("app.log", blobSink.LastTarget.Path);
+        await publisher.DidNotReceive().PublishAsync(Arg.Any<FilePublishRequest>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/test/FileHorizon.Application.Tests/AzureBlobDestinationValidatorTests.cs
+++ b/test/FileHorizon.Application.Tests/AzureBlobDestinationValidatorTests.cs
@@ -1,0 +1,128 @@
+using FileHorizon.Application.Configuration;
+
+namespace FileHorizon.Application.Tests;
+
+public class AzureBlobDestinationValidatorTests
+{
+    private readonly DestinationsOptionsValidator _validator = new();
+
+    private static DestinationsOptions Options(Action<AzureBlobDestinationOptions>? configure = null)
+    {
+        var d = new AzureBlobDestinationOptions
+        {
+            Name = "archive",
+            ContainerName = "incoming",
+            BlobTechnical = new AzureBlobTechnicalOptions { AccountName = "myaccount" }
+        };
+        configure?.Invoke(d);
+        return new DestinationsOptions { AzureBlob = [d] };
+    }
+
+    [Fact]
+    public void Validate_ValidManagedIdentityConfig_Succeeds()
+    {
+        var result = _validator.Validate(null, Options());
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_ValidConnectionStringConfig_Succeeds()
+    {
+        var result = _validator.Validate(null, Options(d =>
+            d.BlobTechnical = new AzureBlobTechnicalOptions { ConnectionString = "UseDevelopmentStorage=true" }));
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_MissingName_Fails()
+    {
+        var result = _validator.Validate(null, Options(d => d.Name = ""));
+        Assert.False(result.Succeeded);
+        Assert.Contains("Name must be specified", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_MissingContainerName_Fails()
+    {
+        var result = _validator.Validate(null, Options(d => d.ContainerName = ""));
+        Assert.False(result.Succeeded);
+        Assert.Contains("ContainerName must be specified", result.FailureMessage);
+    }
+
+    [Theory]
+    [InlineData("UPPER")]
+    [InlineData("ab")]
+    [InlineData("has_underscore")]
+    [InlineData("double--hyphen")]
+    [InlineData("-leadinghyphen")]
+    public void Validate_InvalidContainerName_Fails(string containerName)
+    {
+        var result = _validator.Validate(null, Options(d => d.ContainerName = containerName));
+        Assert.False(result.Succeeded);
+        Assert.Contains("ContainerName", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_InvalidAccessTier_Fails()
+    {
+        var result = _validator.Validate(null, Options(d => d.AccessTier = "Lukewarm"));
+        Assert.False(result.Succeeded);
+        Assert.Contains("AccessTier", result.FailureMessage);
+    }
+
+    [Theory]
+    [InlineData("Hot")]
+    [InlineData("cool")]
+    [InlineData("Cold")]
+    [InlineData("Archive")]
+    public void Validate_ValidAccessTier_Succeeds(string tier)
+    {
+        var result = _validator.Validate(null, Options(d => d.AccessTier = tier));
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_ProvidedStrategy_WithoutContentType_Fails()
+    {
+        var result = _validator.Validate(null, Options(d => d.ContentTypeStrategy = BlobContentTypeStrategy.Provided));
+        Assert.False(result.Succeeded);
+        Assert.Contains("ContentType must be specified", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_NoAuthenticationMethod_Fails()
+    {
+        var result = _validator.Validate(null, Options(d => d.BlobTechnical = new AzureBlobTechnicalOptions()));
+        Assert.False(result.Succeeded);
+        Assert.Contains("ConnectionString", result.FailureMessage);
+        Assert.Contains("AccountName", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_InvalidServiceUri_Fails()
+    {
+        var result = _validator.Validate(null, Options(d =>
+            d.BlobTechnical = new AzureBlobTechnicalOptions { ServiceUri = "not a uri" }));
+        Assert.False(result.Succeeded);
+        Assert.Contains("ServiceUri", result.FailureMessage);
+    }
+
+    [Fact]
+    public void Validate_DuplicateName_AcrossKinds_Fails()
+    {
+        var options = Options();
+        options.Local = [new LocalDestinationOptions { Name = "archive", RootPath = "C:/out" }];
+        var result = _validator.Validate(null, options);
+        Assert.False(result.Succeeded);
+        Assert.Contains("duplicated", result.FailureMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_NegativeMaxRetries_Fails()
+    {
+        var result = _validator.Validate(null, Options(d =>
+            d.BlobTechnical = new AzureBlobTechnicalOptions { AccountName = "myaccount", MaxRetries = -1 }));
+        Assert.False(result.Succeeded);
+        Assert.Contains("MaxRetries", result.FailureMessage);
+    }
+}

--- a/test/FileHorizon.Application.Tests/AzureBlobFileSinkTests.cs
+++ b/test/FileHorizon.Application.Tests/AzureBlobFileSinkTests.cs
@@ -1,0 +1,184 @@
+using System.Text;
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Common;
+using FileHorizon.Application.Configuration;
+using FileHorizon.Application.Infrastructure.Processing;
+using FileHorizon.Application.Models;
+using FileHorizon.Application.Tests.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace FileHorizon.Application.Tests;
+
+public class AzureBlobFileSinkTests
+{
+    private sealed class FakeBlobStorageClient : IBlobStorageClient
+    {
+        public BlobUploadRequest? LastRequest { get; private set; }
+        public Result<BlobUploadResult>? NextResult { get; set; }
+
+        public Task<Result<BlobUploadResult>> UploadAsync(BlobUploadRequest request, Stream content, CancellationToken ct)
+        {
+            LastRequest = request;
+            return Task.FromResult(NextResult ?? Result<BlobUploadResult>.Success(new BlobUploadResult(
+                AccountName: "testaccount",
+                ContainerName: request.ContainerName,
+                BlobPath: request.BlobPath,
+                BlobUri: new Uri($"https://testaccount.blob.core.windows.net/{request.ContainerName}/{request.BlobPath}"),
+                BytesWritten: content.CanSeek ? content.Length : 0)));
+        }
+    }
+
+    private static AzureBlobDestinationOptions Destination(Action<AzureBlobDestinationOptions>? configure = null)
+    {
+        var d = new AzureBlobDestinationOptions
+        {
+            Name = "archive",
+            ContainerName = "incoming",
+            BlobTechnical = new AzureBlobTechnicalOptions { AccountName = "testaccount" }
+        };
+        configure?.Invoke(d);
+        return d;
+    }
+
+    private static (AzureBlobFileSink Sink, FakeBlobStorageClient Client) CreateSink(
+        AzureBlobDestinationOptions destination, IFileTypeDetector? detector = null)
+    {
+        var client = new FakeBlobStorageClient();
+        var monitor = new OptionsMonitorStub<DestinationsOptions>(new DestinationsOptions { AzureBlob = [destination] });
+        var sink = new AzureBlobFileSink(
+            NullLogger<AzureBlobFileSink>.Instance,
+            client,
+            monitor,
+            detector ?? new ExtensionFileTypeDetector());
+        return (sink, client);
+    }
+
+    private static FileReference Target(string path, string? sourceName = "archive", string scheme = AzureBlobFileSink.Scheme)
+        => new(scheme, null, null, path, sourceName);
+
+    private static FileWriteOptions WriteOptions(bool overwrite = false) => new(overwrite, false, null);
+
+    private static MemoryStream Content() => new(Encoding.UTF8.GetBytes("hello"));
+
+    [Fact]
+    public async Task WriteAsync_ComposesBlobPath_WithPrefix()
+    {
+        var (sink, client) = CreateSink(Destination(d => d.RootPathPrefix = "ingest/2025/"));
+        var res = await sink.WriteAsync(Target(@"sub\file.txt"), Content(), WriteOptions(), CancellationToken.None);
+        Assert.True(res.IsSuccess);
+        Assert.Equal("ingest/2025/sub/file.txt", client.LastRequest!.BlobPath);
+        Assert.Equal("incoming", client.LastRequest.ContainerName);
+    }
+
+    [Theory]
+    [InlineData(null, "file.txt", "file.txt")]
+    [InlineData("", "file.txt", "file.txt")]
+    [InlineData("/prefix/", "/file.txt", "prefix/file.txt")]
+    [InlineData("a/b", "c/d.bin", "a/b/c/d.bin")]
+    public void ComposeBlobPath_Normalizes(string? prefix, string path, string expected)
+    {
+        Assert.Equal(expected, AzureBlobFileSink.ComposeBlobPath(prefix, path));
+    }
+
+    [Fact]
+    public async Task WriteAsync_Fails_ForUnknownDestination()
+    {
+        var (sink, client) = CreateSink(Destination());
+        var res = await sink.WriteAsync(Target("file.txt", sourceName: "other"), Content(), WriteOptions(), CancellationToken.None);
+        Assert.True(res.IsFailure);
+        Assert.Equal("Storage.NotConfigured", res.Error.Code);
+        Assert.Null(client.LastRequest);
+    }
+
+    [Fact]
+    public async Task WriteAsync_Fails_ForNonBlobScheme()
+    {
+        var (sink, client) = CreateSink(Destination());
+        var res = await sink.WriteAsync(Target("file.txt", scheme: "local"), Content(), WriteOptions(), CancellationToken.None);
+        Assert.True(res.IsFailure);
+        Assert.Equal("Validation.Invalid", res.Error.Code);
+        Assert.Null(client.LastRequest);
+    }
+
+    [Fact]
+    public async Task WriteAsync_OverwritePolicy_Overwrite_Wins_Over_RuleFlag()
+    {
+        var (sink, client) = CreateSink(Destination(d => d.OverwritePolicy = BlobOverwritePolicy.Overwrite));
+        await sink.WriteAsync(Target("file.txt"), Content(), WriteOptions(overwrite: false), CancellationToken.None);
+        Assert.True(client.LastRequest!.Overwrite);
+    }
+
+    [Fact]
+    public async Task WriteAsync_OverwritePolicy_FailIfExists_Wins_Over_RuleFlag()
+    {
+        var (sink, client) = CreateSink(Destination(d => d.OverwritePolicy = BlobOverwritePolicy.FailIfExists));
+        await sink.WriteAsync(Target("file.txt"), Content(), WriteOptions(overwrite: true), CancellationToken.None);
+        Assert.False(client.LastRequest!.Overwrite);
+    }
+
+    [Fact]
+    public async Task WriteAsync_OverwritePolicy_Unset_FollowsRuleFlag()
+    {
+        var (sink, client) = CreateSink(Destination());
+        await sink.WriteAsync(Target("file.txt"), Content(), WriteOptions(overwrite: true), CancellationToken.None);
+        Assert.True(client.LastRequest!.Overwrite);
+
+        await sink.WriteAsync(Target("file.txt"), Content(), WriteOptions(overwrite: false), CancellationToken.None);
+        Assert.False(client.LastRequest!.Overwrite);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ContentType_Provided_UsesConfiguredValue()
+    {
+        var (sink, client) = CreateSink(Destination(d =>
+        {
+            d.ContentTypeStrategy = BlobContentTypeStrategy.Provided;
+            d.ContentType = "application/x-custom";
+        }));
+        await sink.WriteAsync(Target("file.bin"), Content(), WriteOptions(), CancellationToken.None);
+        Assert.Equal("application/x-custom", client.LastRequest!.ContentType);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ContentType_None_SendsNull()
+    {
+        var (sink, client) = CreateSink(Destination(d => d.ContentTypeStrategy = BlobContentTypeStrategy.None));
+        await sink.WriteAsync(Target("file.txt"), Content(), WriteOptions(), CancellationToken.None);
+        Assert.Null(client.LastRequest!.ContentType);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ContentType_Inferred_FromExtension()
+    {
+        var (sink, client) = CreateSink(Destination());
+        await sink.WriteAsync(Target("file.txt"), Content(), WriteOptions(), CancellationToken.None);
+        Assert.Equal("text/plain", client.LastRequest!.ContentType);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ContentType_FallsBack_To_OctetStream_WhenUnknown()
+    {
+        var (sink, client) = CreateSink(Destination());
+        await sink.WriteAsync(Target("file.unknownext"), Content(), WriteOptions(), CancellationToken.None);
+        Assert.Equal("application/octet-stream", client.LastRequest!.ContentType);
+    }
+
+    [Fact]
+    public async Task WriteAsync_PassesThrough_AccessTier()
+    {
+        var (sink, client) = CreateSink(Destination(d => d.AccessTier = "Cool"));
+        await sink.WriteAsync(Target("file.txt"), Content(), WriteOptions(), CancellationToken.None);
+        Assert.Equal("Cool", client.LastRequest!.AccessTier);
+    }
+
+    [Fact]
+    public async Task WriteAsync_Propagates_ClientFailure()
+    {
+        var (sink, client) = CreateSink(Destination());
+        client.NextResult = Result<BlobUploadResult>.Failure(Error.Storage.AlreadyExists("incoming/file.txt"));
+        var res = await sink.WriteAsync(Target("file.txt"), Content(), WriteOptions(), CancellationToken.None);
+        Assert.True(res.IsFailure);
+        Assert.Equal("Storage.AlreadyExists", res.Error.Code);
+    }
+}

--- a/test/FileHorizon.Application.Tests/AzureBlobStorageClientTests.cs
+++ b/test/FileHorizon.Application.Tests/AzureBlobStorageClientTests.cs
@@ -1,0 +1,79 @@
+using Azure;
+using FileHorizon.Application.Configuration;
+using FileHorizon.Application.Infrastructure.Storage;
+using FileHorizon.Application.Models;
+using FileHorizon.Application.Tests.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FileHorizon.Application.Tests;
+
+public class AzureBlobStorageClientTests
+{
+    private static readonly BlobUploadRequest Request = new(
+        DestinationName: "archive",
+        ContainerName: "incoming",
+        BlobPath: "sub/file.txt",
+        ContentType: "text/plain",
+        Overwrite: false,
+        AccessTier: null);
+
+    [Theory]
+    [InlineData(409, "BlobAlreadyExists", "Storage.AlreadyExists")]
+    [InlineData(409, "ConditionNotMet", "Storage.AlreadyExists")]
+    [InlineData(404, "ContainerNotFound", "Storage.ContainerMissing")]
+    [InlineData(401, null, "Storage.Authorization")]
+    [InlineData(403, "AuthorizationPermissionMismatch", "Storage.Authorization")]
+    [InlineData(429, null, "Storage.UploadTransient")]
+    [InlineData(500, "InternalError", "Storage.UploadTransient")]
+    [InlineData(503, "ServerBusy", "Storage.UploadTransient")]
+    [InlineData(400, "InvalidHeaderValue", "Storage.UploadError")]
+    public void MapError_Translates_RequestFailures(int status, string? errorCode, string expectedCode)
+    {
+        var ex = new RequestFailedException(status, "simulated failure", errorCode, null);
+        var error = AzureBlobStorageClient.MapError(ex, Request);
+        Assert.Equal(expectedCode, error.Code);
+    }
+
+    [Fact]
+    public void MapError_Message_Is_SingleLine()
+    {
+        var ex = new RequestFailedException(500, "first line\r\nHeaders:\r\nAuthorization: secret", null, null);
+        var error = AzureBlobStorageClient.MapError(ex, Request);
+        Assert.Equal("first line", error.Message);
+        Assert.DoesNotContain("secret", error.Message);
+    }
+
+    [Fact]
+    public async Task UploadAsync_Fails_When_Destination_NotConfigured()
+    {
+        var client = new AzureBlobStorageClient(
+            NullLogger<AzureBlobStorageClient>.Instance,
+            new OptionsMonitorStub<DestinationsOptions>(new DestinationsOptions()));
+        var res = await client.UploadAsync(Request, new MemoryStream([1, 2, 3]), CancellationToken.None);
+        Assert.True(res.IsFailure);
+        Assert.Equal("Storage.NotConfigured", res.Error.Code);
+    }
+
+    [Fact]
+    public async Task UploadAsync_Fails_When_No_Auth_Configured()
+    {
+        var destinations = new DestinationsOptions
+        {
+            AzureBlob =
+            [
+                new AzureBlobDestinationOptions
+                {
+                    Name = "archive",
+                    ContainerName = "incoming",
+                    BlobTechnical = new AzureBlobTechnicalOptions() // neither connection string, account nor service uri
+                }
+            ]
+        };
+        var client = new AzureBlobStorageClient(
+            NullLogger<AzureBlobStorageClient>.Instance,
+            new OptionsMonitorStub<DestinationsOptions>(destinations));
+        var res = await client.UploadAsync(Request, new MemoryStream([1, 2, 3]), CancellationToken.None);
+        Assert.True(res.IsFailure);
+        Assert.Equal("Storage.NotConfigured", res.Error.Code);
+    }
+}

--- a/test/FileHorizon.Application.Tests/ServiceRegistrationTests.cs
+++ b/test/FileHorizon.Application.Tests/ServiceRegistrationTests.cs
@@ -131,6 +131,16 @@ public class ServiceRegistrationTests
         Assert.IsType<DisabledFileContentPublisher>(publisher);
     }
 
+    [Fact]
+    public void AzureBlobSink_And_BlobStorageClient_Are_Registered()
+    {
+        using var sp = BuildServiceProvider();
+        var sinks = sp.GetServices<IFileSink>();
+        Assert.Contains(sinks, s => s is Infrastructure.Processing.AzureBlobFileSink);
+        var blobClient = sp.GetRequiredService<IBlobStorageClient>();
+        Assert.IsType<Infrastructure.Storage.AzureBlobStorageClient>(blobClient);
+    }
+
     // Legacy processor removed; orchestrator is the only implementation
     private sealed class TestNoopFileContentPublisher : IFileContentPublisher
     {

--- a/test/FileHorizon.Application.Tests/packages.lock.json
+++ b/test/FileHorizon.Application.Tests/packages.lock.json
@@ -46,15 +46,15 @@
       },
       "Azure.Core": {
         "type": "Transitive",
-        "resolved": "1.53.0",
-        "contentHash": "x9c/toFMOtRrlTdFuE7rlGCVAduQzWVfKmLz5juj41zJAXEhYD5hluiUyyAEzJ6OxpBnKtiaBztzwpZITAVjtg==",
+        "resolved": "1.55.0",
+        "contentHash": "c7femvYS/xEUrLP1sNZN+DoQZmx3X+G3ZXtOOz0RL/7cGMCM3JVqepVmRd3AwM4IK8AtTGS4GOigCO+d/zaSsQ==",
         "dependencies": {
           "Microsoft.Bcl.AsyncInterfaces": "10.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
           "Microsoft.Identity.Client": "4.83.1",
           "Microsoft.Identity.Client.Extensions.Msal": "4.83.1",
-          "System.ClientModel": "1.10.0",
+          "System.ClientModel": "1.11.0",
           "System.Diagnostics.DiagnosticSource": "10.0.3",
           "System.Memory.Data": "10.0.3",
           "System.Text.Encodings.Web": "10.0.3",
@@ -87,6 +87,24 @@
           "Azure.Core": "1.46.2",
           "Azure.Core.Amqp": "1.3.1",
           "Microsoft.Azure.Amqp": "2.7.0"
+        }
+      },
+      "Azure.Storage.Blobs": {
+        "type": "Transitive",
+        "resolved": "12.29.1",
+        "contentHash": "pWh7xZBto8YcwiO853AB3uijTfVqs9PDte0Bu9/Zd8O9nwKiitWm0Jej1vsNkmYUzeG1552f8vJPjmtW30pBUQ==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "Azure.Storage.Common": "12.28.0"
+        }
+      },
+      "Azure.Storage.Common": {
+        "type": "Transitive",
+        "resolved": "12.28.0",
+        "contentHash": "5l8YhNrks38zKLGFW2BBFLwieyamH/xauABSASsdpZv79G0f+n2n22IjkRmUqCmALSupkwRHh2LOhbW3yj5Qgw==",
+        "dependencies": {
+          "Azure.Core": "1.55.0",
+          "System.IO.Hashing": "10.0.3"
         }
       },
       "BouncyCastle.Cryptography": {
@@ -268,8 +286,8 @@
       },
       "System.ClientModel": {
         "type": "Transitive",
-        "resolved": "1.10.0",
-        "contentHash": "lBEWs54F5Y5pZ9hC+8z4S/X76957ex+DPk7WecRHlbIHtrPfbRMMlOgI3iDn4Jpb3bSxvBnKaaHoD59auFjlBA==",
+        "resolved": "1.11.0",
+        "contentHash": "1Wl32zh7TbvN+HAO8NqDuaN0Ao2Qu/0j0NJSrXGDtpUQsTXQYJ3C6hd9/Ds2IrgP4agMQYFoXB35GZfC21ByHw==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.3",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.3",
@@ -296,8 +314,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
+        "resolved": "10.0.3",
+        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
@@ -394,6 +412,7 @@
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
           "Azure.Messaging.ServiceBus": "[7.20.1, )",
+          "Azure.Storage.Blobs": "[12.29.1, )",
           "FluentFTP": "[54.2.0, )",
           "Microsoft.Extensions.FileSystemGlobbing": "[10.0.9, )",
           "SSH.NET": "[2025.1.0, )",


### PR DESCRIPTION
Closes #17

Adds Azure Blob Storage as a first-class sink destination, following the existing Local/Service Bus destination patterns.

## What's included

- **New destination type `AzureBlob`** resolvable via routing: `DestinationKind.AzureBlob`, router resolution in `SimpleFileRouter`, and a `ProcessAzureBlobAsync` dispatch path in the orchestrator — so idempotency tracking and delete-after-transfer apply to blob destinations automatically.
- **Configuration** (`Destinations:AzureBlob`): `ContainerName`, optional `RootPathPrefix`, `AccessTier` (Hot/Cool/Cold/Archive, validated), `ContentTypeStrategy` (`InferFromExtension` default / `Provided` / `None`), `OverwritePolicy` (`FailIfExists` / `Overwrite`), and a `BlobTechnical` block mirroring `ServiceBusTechnical` for auth (connection string, or managed identity via `AccountName`/`ServiceUri` + optional `ManagedIdentityClientId`) and retry tuning. Full validation in `DestinationsOptionsValidator` including container-name rules and cross-kind name uniqueness.
- **`IBlobStorageClient` abstraction** (per the issue's implementation sketch) with `AzureBlobStorageClient` in `Infrastructure/Storage/`: streaming upload via `Azure.Storage.Blobs` async APIs (no full buffering), per-destination client caching, `DefaultAzureCredential` flow copied from the Service Bus publisher, and SDK exponential retry for transient failures (429/5xx/timeouts) configured per destination.
- **`AzureBlobFileSink`** (`IFileSink`, name `AzureBlob`): path composition/normalization with the configured prefix, content type per strategy (inference reuses `IFileTypeDetector`), overwrite resolution, `sink.write` activity with `blob.account`, `blob.container`, `blob.path`, `blob.tier` tags.
- **Error mapping** to a new `Error.Storage` category: `AlreadyExists`, `ContainerMissing`, `Authorization`, `UploadTransient`, `UploadError` — SDK exceptions never escape as raw exceptions, and error messages are trimmed to their first line so response headers/URLs (e.g. SAS details) can't leak into logs or results.
- **Metrics** on the shared `FileHorizon` meter: `blob.upload.bytes`, `blob.upload.duration.ms`, `blob.upload.successes` (tagged with `tier`), `blob.upload.failures` (tagged with `reason`).
- **Successful writes return an artifact reference** (`BlobUploadResult` with account, container, path, URI, bytes written).
- **Tests** (37 new, all 219 passing): sink behavior via a fake `IBlobStorageClient` (path composition, overwrite policies, content type strategies, tier passthrough, error propagation), `RequestFailedException` → domain error translation, options validator rules, router kind resolution, orchestrator dispatch, and DI registration.
- **Docs**: README section with config example + Azurite instructions; architecture doc status table updated.

## Deviations from the issue

- No explicit `ConnectionStrategy` field — the strategy is implied by which auth setting is present, matching how Service Bus destinations already work.
- `OverwritePolicy` is optional: when omitted, the routing rule's existing `Overwrite` flag applies, so the two config surfaces don't conflict. `FailIfExists` is enforced server-side with `If-None-Match: *` (race-safe), surfacing as `Storage.AlreadyExists`.
- `Cold` tier accepted in addition to Hot/Cool/Archive since the service and SDK support it.
- The `blob.access.tier` info metric is implemented as a `tier` tag on `blob.upload.successes`.
- No Azurite integration test scaffolding yet (repo has no emulator/Testcontainers precedent); the client is exercised through the abstraction, and `UseDevelopmentStorage=true` works against Azurite for manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
