### PR TITLE
fix(routing): apply RenamePattern exactly once, owned by the router

### DIFF
--- a/docs/processing-architecture.md
+++ b/docs/processing-architecture.md
@@ -44,7 +44,7 @@ public interface IFileRouter
 
 public sealed record FileReference(string Scheme, string? Host, int? Port, string Path, string? SourceName);
 public sealed record FileAttributesInfo(long Size, DateTimeOffset LastWriteUtc, string? Hash);
-public sealed record FileWriteOptions(bool Overwrite, bool ComputeHash, string? RenamePattern);
+public sealed record FileWriteOptions(bool Overwrite, bool ComputeHash);
 public sealed record DestinationPlan(string DestinationName, string TargetPath, FileWriteOptions Options);
 ```
 

--- a/src/FileHorizon.Application/Infrastructure/Processing/LocalFileSink.cs
+++ b/src/FileHorizon.Application/Infrastructure/Processing/LocalFileSink.cs
@@ -21,7 +21,7 @@ public sealed class LocalFileSink(ILogger<LocalFileSink> logger) : IFileSink
                 return Result.Failure(Error.Validation.Invalid($"LocalFileSink received non-local scheme '{target.Scheme}'"));
             }
 
-            var destPath = ApplyRename(target.Path, options?.RenamePattern);
+            var destPath = target.Path;
             var dir = Path.GetDirectoryName(destPath);
             if (!string.IsNullOrWhiteSpace(dir) && !Directory.Exists(dir))
             {
@@ -56,17 +56,5 @@ public sealed class LocalFileSink(ILogger<LocalFileSink> logger) : IFileSink
             _logger.LogError(ex, "Unexpected error writing to {Path}", target.Path);
             return Result.Failure(Error.Unspecified("LocalSink.Unexpected", ex.Message));
         }
-    }
-
-    private static string ApplyRename(string path, string? renamePattern)
-    {
-        if (string.IsNullOrWhiteSpace(renamePattern)) return path;
-        var fileName = Path.GetFileName(path);
-        var date = DateTimeOffset.UtcNow;
-        var replaced = renamePattern
-            .Replace("{fileName}", fileName)
-            .Replace("{yyyyMMdd}", date.ToString("yyyyMMdd"));
-        var dir = Path.GetDirectoryName(path) ?? string.Empty;
-        return Path.Combine(dir, replaced);
     }
 }

--- a/src/FileHorizon.Application/Infrastructure/Processing/SimpleFileRouter.cs
+++ b/src/FileHorizon.Application/Infrastructure/Processing/SimpleFileRouter.cs
@@ -42,12 +42,12 @@ public sealed class SimpleFileRouter(
                 }
             }
             var fileName = Path.GetFileName(fileEvent.Metadata.SourcePath);
-            var renamePattern = rule.RenamePattern;
-            var targetName = ApplyRename(fileName, renamePattern);
+            // The router is the single owner of RenamePattern: it is applied here to TargetPath and
+            // must not be re-applied by sinks (double application expands tokens twice, see #29).
+            var targetName = ApplyRename(fileName, rule.RenamePattern);
             var writeOptions = new FileWriteOptions(
                 Overwrite: rule.Overwrite ?? false,
-                ComputeHash: false,
-                RenamePattern: renamePattern);
+                ComputeHash: false);
 
             var plan = new DestinationPlan(destinationName, targetName, writeOptions, kind, isTopic);
             _logger.LogDebug("Router matched rule {Rule} -> {Destination}", rule.Name, destinationName);

--- a/src/FileHorizon.Application/Models/FileWriteOptions.cs
+++ b/src/FileHorizon.Application/Models/FileWriteOptions.cs
@@ -2,5 +2,4 @@ namespace FileHorizon.Application.Models;
 
 public sealed record FileWriteOptions(
     bool Overwrite,
-    bool ComputeHash,
-    string? RenamePattern);
+    bool ComputeHash);

--- a/test/FileHorizon.Application.Tests/AzureBlobFileSinkTests.cs
+++ b/test/FileHorizon.Application.Tests/AzureBlobFileSinkTests.cs
@@ -57,7 +57,7 @@ public class AzureBlobFileSinkTests
     private static FileReference Target(string path, string? sourceName = "archive", string scheme = AzureBlobFileSink.Scheme)
         => new(scheme, null, null, path, sourceName);
 
-    private static FileWriteOptions WriteOptions(bool overwrite = false) => new(overwrite, false, null);
+    private static FileWriteOptions WriteOptions(bool overwrite = false) => new(overwrite, false);
 
     private static MemoryStream Content() => new(Encoding.UTF8.GetBytes("hello"));
 

--- a/test/FileHorizon.Application.Tests/FileProcessingOrchestratorTests.cs
+++ b/test/FileHorizon.Application.Tests/FileProcessingOrchestratorTests.cs
@@ -103,6 +103,87 @@ public class FileProcessingOrchestratorTests
         try { Directory.Delete(destRoot, true); } catch { }
     }
 
+    [Fact]
+    public async Task ProcessAsync_AppliesRenamePattern_ExactlyOnce()
+    {
+        // Regression test for #29: with a non-idempotent pattern the router and the sink each
+        // applying RenamePattern produced names like "20250101-20250101-file.txt".
+        var srcFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N") + ".txt");
+        var destRoot = Path.Combine(Path.GetTempPath(), "orchestrator-tests", Guid.NewGuid().ToString("N"));
+        await File.WriteAllTextAsync(srcFile, "hello world");
+
+        var ev = new FileEvent(
+            Id: Guid.NewGuid().ToString("N"),
+            Metadata: new FileMetadata(srcFile, new FileInfo(srcFile).Length, DateTimeOffset.UtcNow, "none", null),
+            DiscoveredAtUtc: DateTimeOffset.UtcNow,
+            Protocol: "local",
+            DestinationPath: string.Empty,
+            DeleteAfterTransfer: false);
+
+        var routing = new RoutingOptions
+        {
+            Rules =
+            [
+                new RoutingRuleOptions
+                {
+                    Name = "local",
+                    Protocol = "local",
+                    PathGlob = "**/*.txt",
+                    Destinations = ["OutboxA"],
+                    Overwrite = true,
+                    RenamePattern = "{yyyyMMdd}-{fileName}"
+                }
+            ]
+        };
+        var destinations = new DestinationsOptions
+        {
+            Local =
+            [
+                new LocalDestinationOptions { Name = "OutboxA", RootPath = destRoot }
+            ]
+        };
+        var router = new Infrastructure.Processing.SimpleFileRouter(
+            routingOptions: new StaticOptionsMonitor<RoutingOptions>(routing),
+            destinationsOptions: new StaticOptionsMonitor<DestinationsOptions>(destinations),
+            logger: NullLogger<Infrastructure.Processing.SimpleFileRouter>.Instance
+        );
+
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+        var orchestrator = new FileProcessingOrchestrator(
+            router: router,
+            readers: [new Infrastructure.Processing.LocalFileContentReader(NullLogger<Infrastructure.Processing.LocalFileContentReader>.Instance)],
+            sinks: [new Infrastructure.Processing.LocalFileSink(NullLogger<Infrastructure.Processing.LocalFileSink>.Instance)],
+            destinations: new StaticOptionsMonitor<DestinationsOptions>(destinations),
+            idempotencyOptions: new StaticOptionsMonitor<IdempotencyOptions>(new IdempotencyOptions { Enabled = false }),
+            remoteSources: new StaticOptionsMonitor<RemoteFileSourcesOptions>(new RemoteFileSourcesOptions()),
+            idempotencyStore: new Infrastructure.Idempotency.InMemoryIdempotencyStore(),
+            sftpFactory: new Infrastructure.Remote.SshNetSftpClientFactory(NullLogger<Infrastructure.Remote.SshNetSftpClientFactory>.Instance),
+            secretResolver: new Infrastructure.Secrets.InMemorySecretResolver(configuration, NullLogger<Infrastructure.Secrets.InMemorySecretResolver>.Instance),
+            sftpClientLogger: NullLogger<Infrastructure.Remote.SftpRemoteFileClient>.Instance,
+            ftpClientLogger: NullLogger<Infrastructure.Remote.FtpRemoteFileClient>.Instance,
+            publisher: new FakePublisher(),
+            fileTypeDetector: new Infrastructure.Processing.ExtensionFileTypeDetector(),
+            logger: NullLogger<FileProcessingOrchestrator>.Instance
+        );
+
+        try
+        {
+            var res = await orchestrator.ProcessAsync(ev, CancellationToken.None);
+            Assert.True(res.IsSuccess);
+
+            var date = DateTimeOffset.UtcNow.ToString("yyyyMMdd");
+            var expected = Path.Combine(destRoot, $"{date}-{Path.GetFileName(srcFile)}");
+            var written = Directory.GetFiles(destRoot);
+            Assert.Single(written);
+            Assert.Equal(expected, written[0]);
+        }
+        finally
+        {
+            try { File.Delete(srcFile); } catch { }
+            try { Directory.Delete(destRoot, true); } catch { }
+        }
+    }
+
     private sealed class FakePublisher : IFileContentPublisher
     {
         public bool Called { get; private set; }

--- a/test/FileHorizon.Application.Tests/LocalFileSinkTests.cs
+++ b/test/FileHorizon.Application.Tests/LocalFileSinkTests.cs
@@ -25,7 +25,7 @@ public class LocalFileSinkTests
             var data = new byte[5 * 1024 * 1024]; // 5 MB
             new Random(42).NextBytes(data); // Devskim: ignore DS148264 - Test code
             await using var input = new MemoryStream(data);
-            var res = await sink.WriteAsync(new FileReference("local", null, null, dest, "Dest"), input, new FileWriteOptions(true, false, null), CancellationToken.None);
+            var res = await sink.WriteAsync(new FileReference("local", null, null, dest, "Dest"), input, new FileWriteOptions(true, false), CancellationToken.None);
             Assert.True(res.IsSuccess);
             Assert.True(File.Exists(dest));
             var writtenLen = new FileInfo(dest).Length;
@@ -46,7 +46,7 @@ public class LocalFileSinkTests
             var dest = Path.Combine(dir, "out", "a.txt");
             var sink = new LocalFileSink(NullLogger<LocalFileSink>.Instance);
             await using var input = new MemoryStream(Encoding.UTF8.GetBytes("hello"));
-            var res = await sink.WriteAsync(new FileReference("local", null, null, dest, "Dest"), input, new FileWriteOptions(true, false, null), CancellationToken.None);
+            var res = await sink.WriteAsync(new FileReference("local", null, null, dest, "Dest"), input, new FileWriteOptions(true, false), CancellationToken.None);
             Assert.True(res.IsSuccess);
             Assert.True(File.Exists(dest));
             var text = await File.ReadAllTextAsync(dest);
@@ -68,7 +68,7 @@ public class LocalFileSinkTests
             await File.WriteAllTextAsync(dest, "existing");
             var sink = new LocalFileSink(NullLogger<LocalFileSink>.Instance);
             await using var input = new MemoryStream(Encoding.UTF8.GetBytes("new"));
-            var res = await sink.WriteAsync(new FileReference("local", null, null, dest, "Dest"), input, new FileWriteOptions(false, false, null), CancellationToken.None);
+            var res = await sink.WriteAsync(new FileReference("local", null, null, dest, "Dest"), input, new FileWriteOptions(false, false), CancellationToken.None);
             Assert.True(res.IsFailure);
             Assert.Equal("existing", await File.ReadAllTextAsync(dest));
         }
@@ -79,20 +79,20 @@ public class LocalFileSinkTests
     }
 
     [Fact]
-    public async Task WriteAsync_AppliesRenamePattern()
+    public async Task WriteAsync_WritesTo_ExactTargetPath()
     {
+        // Rename patterns are applied by the router when building TargetPath (#29);
+        // the sink must write to the path it is given, without re-applying any pattern.
         var dir = CreateTempDir();
         try
         {
-            var dest = Path.Combine(dir, "nested", "name.txt");
+            var dest = Path.Combine(dir, "nested", "20250101-name.txt");
             var sink = new LocalFileSink(NullLogger<LocalFileSink>.Instance);
             await using var input = new MemoryStream(Encoding.UTF8.GetBytes("x"));
-            var res = await sink.WriteAsync(new FileReference("local", null, null, dest, "Dest"), input, new FileWriteOptions(true, false, "{yyyyMMdd}-{fileName}"), CancellationToken.None);
+            var res = await sink.WriteAsync(new FileReference("local", null, null, dest, "Dest"), input, new FileWriteOptions(true, false), CancellationToken.None);
             Assert.True(res.IsSuccess);
-            var expectedPrefix = DateTimeOffset.UtcNow.ToString("yyyyMMdd") + "-";
-            var dirPath = Path.GetDirectoryName(dest)!;
-            var files = Directory.GetFiles(dirPath);
-            Assert.Contains(files, f => Path.GetFileName(f).StartsWith(expectedPrefix));
+            Assert.True(File.Exists(dest));
+            Assert.Single(Directory.GetFiles(Path.GetDirectoryName(dest)!));
         }
         finally
         {


### PR DESCRIPTION
Fixes #29

`SimpleFileRouter` applied `RenamePattern` when building `plan.TargetPath` and *also* forwarded the pattern via `FileWriteOptions`, where `LocalFileSink` applied it a second time to the already-renamed name. Any pattern containing expandable tokens was expanded twice — `{yyyyMMdd}-{fileName}` produced `20250101-20250101-file.txt`.

## Change

The router is now the single owner of rename application (matching how the Azure Blob sink from #28 already behaves):

- `FileWriteOptions.RenamePattern` removed — the record is now `(bool Overwrite, bool ComputeHash)`. Nothing outside `LocalFileSink` read it.
- `LocalFileSink` writes to the exact target path it is given; its private `ApplyRename` is deleted.
- Comment added at the router's `ApplyRename` call marking it as the single application point.

## Tests

- Replaced `LocalFileSinkTests.WriteAsync_AppliesRenamePattern` (which validated the sink-side rename in isolation and therefore masked the bug) with `WriteAsync_WritesTo_ExactTargetPath`.
- Added `FileProcessingOrchestratorTests.ProcessAsync_AppliesRenamePattern_ExactlyOnce` — a router → orchestrator → sink test using the non-idempotent pattern `{yyyyMMdd}-{fileName}`, asserting exactly one file with a single date prefix. This test fails on `main` prior to this change.

All 220 tests pass.

## Compatibility note

`FileWriteOptions` loses its third positional parameter, so external `IFileSink` implementations constructing or reading `RenamePattern` would need a one-line adjustment. Routing configuration is unaffected — `RenamePattern` on routing rules works exactly as documented, just applied once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
