### PR TITLE
feat(idempotency): add --seed-idempotency flag to adopt sources with a backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Because it runs inside the normal host, it uses the same `appsettings.json`, sec
 Notes:
 
 - **Stop the service first.** The file-backed store opens `idempotency.jsonl` with `FileShare.Read`, so a running instance blocks the seeder.
-- A durable store is required — seeding refuses to run against the in-memory store, since the markers would vanish when the process exits.
+- A durable store is required — seeding refuses to run against the in-memory store, since the markers would vanish when the process exits. The refusal distinguishes the two ways of ending up there: no durable store configured, or one configured that would not open (a locked file being the usual cause), in which case it prints the underlying error rather than pointing at configuration.
 - Seeding a file that is mid-upload is harmless: the completed file has a different size or mtime, hence a different key, and still transfers.
 - Marker keys have the form `fh:idemp:v2:{identityKey}|{size}|{mtime}`, e.g. `fh:idemp:v2:sftp://host:22/upload/a.zip|1234|2026-07-14T09:13:22.0000000+00:00`. Note the `+00:00` offset rather than `Z`; prefer this command over hand-writing markers, since a mismatched key is skipped with only a warning and the file transfers anyway.
 

--- a/README.md
+++ b/README.md
@@ -280,6 +280,32 @@ Notes:
 
 For a deeper overview see `docs/processing-architecture.md`.
 
+### Adopting a source that already has a backlog
+
+Pointing FileHorizon at a remote source that already holds files means the first two poll cycles enqueue every one of them (a file is never ready on first sighting — see `MinStableSeconds`). For a source holding thousands of files that is a long, unintended bulk transfer.
+
+To adopt such a source without transferring its history, seed the idempotency store first:
+
+```
+FileHorizon.Host.exe --seed-idempotency --source PartnerSftp [--pattern "*.zip"] [--dry-run]
+```
+
+This lists the configured source, writes an idempotency marker for every matching file, and exits without starting the pipeline. Files already present are then suppressed; only files arriving afterwards are transferred. Fetch the historical files by whatever means suits you.
+
+Because it runs inside the normal host, it uses the same `appsettings.json`, secret resolution, host key validation and remote client as the poller, so the keys it writes are the keys the pipeline will look up. Markers are written through `IIdempotencyStore`, so the Redis store works the same way.
+
+- `--source` is required and names an entry under `RemoteFileSources:Sftp` or `RemoteFileSources:Ftp`. The relevant `Features:Enable*Poller` flag must be on.
+- `--pattern` overrides the source's configured `Pattern`, for seeding a subset.
+- `--dry-run` reports the count and a few sample keys without writing anything.
+- Exit codes: `0` success, `1` seeding failed, `2` bad arguments or unusable configuration.
+
+Notes:
+
+- **Stop the service first.** The file-backed store opens `idempotency.jsonl` with `FileShare.Read`, so a running instance blocks the seeder.
+- A durable store is required — seeding refuses to run against the in-memory store, since the markers would vanish when the process exits.
+- Seeding a file that is mid-upload is harmless: the completed file has a different size or mtime, hence a different key, and still transfers.
+- Marker keys have the form `fh:idemp:v2:{identityKey}|{size}|{mtime}`, e.g. `fh:idemp:v2:sftp://host:22/upload/a.zip|1234|2026-07-14T09:13:22.0000000+00:00`. Note the `+00:00` offset rather than `Z`; prefer this command over hand-writing markers, since a mismatched key is skipped with only a warning and the file transfers anyway.
+
 ### Destinations: Adding Azure Service Bus
 
 Destinations now support a Service Bus variant alongside `Local` and `Sftp`. A Service Bus destination allows routing rules to direct a file's full content into a queue or topic after it has been read. The orchestrator identifies the destination kind and invokes the `IFileContentPublisher` abstraction instead of a file sink.

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Because it runs inside the normal host, it uses the same `appsettings.json`, sec
 
 Notes:
 
-- **Stop the service first.** The file-backed store opens `idempotency.jsonl` with `FileShare.Read`, so a running instance blocks the seeder.
+- **Stop the service first.** How this is enforced differs by platform, and only Windows enforces it at all: there, `idempotency.jsonl` is opened with `FileShare.Read` and a running instance blocks the seeder outright. On Linux .NET does not enforce `FileShare` between writers, so both processes open the file happily — and seeding a live instance is ineffective rather than merely untidy, because the store loads markers only at construction. The running instance never sees what the seeder appends and transfers the backlog anyway; the markers only take effect after a restart.
 - A durable store is required — seeding refuses to run against the in-memory store, since the markers would vanish when the process exits. The refusal distinguishes the two ways of ending up there: no durable store configured, or one configured that would not open (a locked file being the usual cause), in which case it prints the underlying error rather than pointing at configuration.
 - Seeding a file that is mid-upload is harmless: the completed file has a different size or mtime, hence a different key, and still transfers.
 - Marker keys have the form `fh:idemp:v2:{identityKey}|{size}|{mtime}`, e.g. `fh:idemp:v2:sftp://host:22/upload/a.zip|1234|2026-07-14T09:13:22.0000000+00:00`. Note the `+00:00` offset rather than `Z`; prefer this command over hand-writing markers, since a mismatched key is skipped with only a warning and the file transfers anyway.

--- a/src/FileHorizon.Application/Infrastructure/Idempotency/IdempotencyStoreDiagnostics.cs
+++ b/src/FileHorizon.Application/Infrastructure/Idempotency/IdempotencyStoreDiagnostics.cs
@@ -1,0 +1,36 @@
+namespace FileHorizon.Application.Infrastructure.Idempotency;
+
+/// <summary>
+/// Records why the idempotency store registration ended up on the store it did.
+/// </summary>
+/// <remarks>
+/// The registration deliberately falls back instead of failing startup, so a transient store problem
+/// degrades the service rather than stopping it, and reports the cause through <c>ILogger</c> only.
+/// An operator running a one-off command in an environment without a console sink never sees that log,
+/// and a caller that *requires* durability would otherwise have to blame configuration for what may
+/// really be a locked file. Capturing the cause here lets the caller name the actual problem.
+/// </remarks>
+public sealed class IdempotencyStoreDiagnostics
+{
+    private volatile DurableStoreFallback? _fallback;
+
+    /// <summary>
+    /// Non-null when a durable store was explicitly configured but could not be constructed, so the
+    /// registration fell back. Null both when nothing durable was configured and when one was opened.
+    /// </summary>
+    public DurableStoreFallback? Fallback => _fallback;
+
+    public void RecordFallback(string store, Exception cause, string? hint = null)
+    {
+        ArgumentNullException.ThrowIfNull(cause);
+        _fallback = new DurableStoreFallback(store, cause.Message, hint);
+    }
+}
+
+/// <summary>
+/// A durable store that was configured but could not be constructed.
+/// </summary>
+/// <param name="Store">Description of the configured store, e.g. the file path it would have used.</param>
+/// <param name="Reason">Message from the exception that prevented construction.</param>
+/// <param name="Hint">Optional next step for whoever is looking at it.</param>
+public sealed record DurableStoreFallback(string Store, string Reason, string? Hint);

--- a/src/FileHorizon.Application/Infrastructure/Polling/IdempotencySeed.cs
+++ b/src/FileHorizon.Application/Infrastructure/Polling/IdempotencySeed.cs
@@ -1,0 +1,31 @@
+namespace FileHorizon.Application.Infrastructure.Polling;
+
+/// <summary>
+/// Parameters for a one-off idempotency seeding run over a single remote source.
+/// </summary>
+/// <param name="SourceName">Name of the configured source to scan.</param>
+/// <param name="PatternOverride">Optional glob replacing the source's configured Pattern, for partial seeding.</param>
+/// <param name="DryRun">When true, count and sample keys are produced but no markers are written.</param>
+/// <param name="Ttl">Marker lifetime; null keeps markers indefinitely, matching Idempotency:TtlSeconds=0.</param>
+public sealed record IdempotencySeedRequest(
+    string SourceName,
+    string? PatternOverride = null,
+    bool DryRun = false,
+    TimeSpan? Ttl = null);
+
+/// <summary>
+/// Outcome of an idempotency seeding run.
+/// </summary>
+/// <param name="SourceName">The source that was scanned.</param>
+/// <param name="Pattern">The pattern actually applied.</param>
+/// <param name="Scanned">Files matched by the pattern.</param>
+/// <param name="Marked">Files newly marked as already transferred (always 0 for a dry run).</param>
+/// <param name="AlreadyMarked">Files that already had a marker.</param>
+/// <param name="SampleKeys">First few generated keys, for eyeballing before committing to a large run.</param>
+public sealed record IdempotencySeedResult(
+    string SourceName,
+    string Pattern,
+    int Scanned,
+    int Marked,
+    int AlreadyMarked,
+    IReadOnlyList<string> SampleKeys);

--- a/src/FileHorizon.Application/Infrastructure/Polling/RemotePollerBase.cs
+++ b/src/FileHorizon.Application/Infrastructure/Polling/RemotePollerBase.cs
@@ -19,6 +19,9 @@ public abstract class RemotePollerBase : IFilePoller
     private readonly TimeSpan _baseBackoff = TimeSpan.FromSeconds(5);
     private readonly TimeSpan _maxBackoff = TimeSpan.FromMinutes(5);
 
+    /// <summary>How many generated keys a seeding run reports back for inspection.</summary>
+    private const int SeedSampleKeyCount = 5;
+
     protected RemotePollerBase(IFileEventQueue queue, IOptionsMonitor<RemoteFileSourcesOptions> remoteOptions, ILogger logger)
     {
         _queue = queue;
@@ -209,12 +212,7 @@ public abstract class RemotePollerBase : IFilePoller
 
     private async Task EnqueueEventAsync(IRemoteFileSourceDescriptor source, IRemoteFileClient client, IRemoteFileInfo file, string identityKey, CancellationToken ct)
     {
-        var metadata = new FileMetadata(
-            SourcePath: identityKey,
-            SizeBytes: file.Size,
-            LastModifiedUtc: file.LastWriteTimeUtc.UtcDateTime,
-            HashAlgorithm: "none",
-            Checksum: null);
+        var metadata = BuildMetadata(file, identityKey);
 
         var destination = source.DestinationPath ?? file.FullPath; // will be mapped later by processor
         var ev = new FileEvent(
@@ -234,6 +232,98 @@ public abstract class RemotePollerBase : IFilePoller
             _logger.LogDebug("Enqueued remote file {Key} ({Protocol})", identityKey, client.Protocol);
             Common.Telemetry.TelemetryInstrumentation.FilesDiscovered.Add(1, KeyValuePair.Create<string, object?>("file.protocol", client.Protocol.ToString().ToLowerInvariant()));
         }
+    }
+
+    /// <summary>
+    /// Builds the metadata identifying one specific version of a remote file. Shared by the dispatch
+    /// path and <see cref="SeedIdempotencyAsync"/> so the two can never produce different identity keys.
+    /// </summary>
+    private static FileMetadata BuildMetadata(IRemoteFileInfo file, string identityKey)
+        => new(
+            SourcePath: identityKey,
+            SizeBytes: file.Size,
+            LastModifiedUtc: file.LastWriteTimeUtc.UtcDateTime,
+            HashAlgorithm: "none",
+            Checksum: null);
+
+    /// <summary>
+    /// Marks every file currently present on the named source as already transferred, without moving any
+    /// data. Used to adopt a source that already holds a backlog: existing files are suppressed and only
+    /// files arriving afterwards are picked up.
+    /// </summary>
+    /// <remarks>
+    /// Markers are written through <see cref="IIdempotencyStore"/> rather than composed by hand, so the
+    /// stored format is whatever the configured store uses. A file that is mid-upload when seeded is
+    /// harmless: the completed file has a different size or mtime and therefore a different key.
+    /// </remarks>
+    public async Task<Result<IdempotencySeedResult>> SeedIdempotencyAsync(
+        IdempotencySeedRequest request,
+        IIdempotencyStore store,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(store);
+
+        var source = GetEnabledSources()
+            .FirstOrDefault(s => string.Equals(s.Name, request.SourceName, StringComparison.OrdinalIgnoreCase));
+        if (source is null)
+        {
+            return Result<IdempotencySeedResult>.Failure(
+                Error.Validation.Invalid($"No enabled source named '{request.SourceName}' is configured for this poller."));
+        }
+
+        var pattern = string.IsNullOrWhiteSpace(request.PatternOverride) ? source.Pattern : request.PatternOverride!;
+        var scanned = 0;
+        var marked = 0;
+        var alreadyMarked = 0;
+        var samples = new List<string>();
+
+        try
+        {
+            await using var client = CreateClient(source);
+            await client.ConnectAsync(ct).ConfigureAwait(false);
+
+            await foreach (var file in client.ListFilesAsync(source.RemotePath, source.Recursive, pattern, ct).ConfigureAwait(false))
+            {
+                if (ct.IsCancellationRequested) break;
+                if (file.IsDirectory) continue;
+
+                var identityKey = ProtocolIdentity.BuildKey(MapProtocolType(client.Protocol), client.Host, client.Port, file.FullPath);
+                var idempotencyKey = FileIdentity.BuildIdempotencyKey(BuildMetadata(file, identityKey));
+
+                scanned++;
+                if (samples.Count < SeedSampleKeyCount)
+                {
+                    samples.Add(idempotencyKey);
+                }
+
+                if (request.DryRun) continue;
+
+                if (await store.TryMarkProcessedAsync(idempotencyKey, request.Ttl, ct).ConfigureAwait(false))
+                {
+                    marked++;
+                }
+                else
+                {
+                    alreadyMarked++;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Markers written before the failure are durable and correct; report progress with the error
+            // so a partial run can simply be repeated.
+            _logger.LogError(ex, "Idempotency seed for source {Source} failed after scanning {Scanned} file(s)", source.Name, scanned);
+            return Result<IdempotencySeedResult>.Failure(
+                Error.Unspecified("Idempotency.SeedFailed", $"Seeding '{source.Name}' failed after {scanned} file(s): {ex.Message}"));
+        }
+
+        _logger.LogInformation(
+            "Idempotency seed for source {Source} (pattern={Pattern}, dryRun={DryRun}): scanned={Scanned}, marked={Marked}, alreadyMarked={AlreadyMarked}",
+            source.Name, pattern, request.DryRun, scanned, marked, alreadyMarked);
+
+        return Result<IdempotencySeedResult>.Success(
+            new IdempotencySeedResult(source.Name, pattern, scanned, marked, alreadyMarked, samples));
     }
 
     protected abstract List<IRemoteFileSourceDescriptor> GetEnabledSources();

--- a/src/FileHorizon.Application/ServiceCollectionExtensions.cs
+++ b/src/FileHorizon.Application/ServiceCollectionExtensions.cs
@@ -130,6 +130,10 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IValidateOptions<Configuration.IdempotencyOptions>, Configuration.IdempotencyOptionsValidator>();
         services.AddOptions<Configuration.ContentDetectionOptions>();
 
+        // Records why the selection below fell back, so a caller that requires a durable store (the
+        // seeding command) can report the real cause instead of only "nothing durable is configured".
+        services.AddSingleton<Infrastructure.Idempotency.IdempotencyStoreDiagnostics>();
+
         // Idempotency store selection: Redis (if enabled) -> file-backed (if DataDirectory set) -> in-memory.
         services.AddSingleton<Abstractions.IIdempotencyStore>(sp =>
         {
@@ -138,6 +142,7 @@ public static class ServiceCollectionExtensions
                         ?? new Configuration.IdempotencyOptions();
             var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
             var logger = loggerFactory.CreateLogger("IdempotencyStoreRegistration");
+            var diagnostics = sp.GetRequiredService<Infrastructure.Idempotency.IdempotencyStoreDiagnostics>();
             if (redis is { Enabled: true })
             {
                 try
@@ -151,13 +156,18 @@ public static class ServiceCollectionExtensions
                 catch (Exception ex)
                 {
                     logger.LogWarning(ex, "Failed to initialize RedisIdempotencyStore; falling back");
+                    diagnostics.RecordFallback(
+                        "the Redis idempotency store",
+                        ex,
+                        "Check Redis connectivity and Redis:Configuration, or unset Redis:Enabled to use the file-backed store.");
                 }
             }
             if (!string.IsNullOrWhiteSpace(idemp.DataDirectory))
             {
+                string? path = null;
                 try
                 {
-                    var path = Path.Combine(idemp.DataDirectory, Infrastructure.Idempotency.FileBackedIdempotencyStore.DefaultFileName);
+                    path = Path.Combine(idemp.DataDirectory, Infrastructure.Idempotency.FileBackedIdempotencyStore.DefaultFileName);
                     logger.LogInformation("Using FileBackedIdempotencyStore at {Path}", path);
                     return new Infrastructure.Idempotency.FileBackedIdempotencyStore(
                         path,
@@ -166,11 +176,24 @@ public static class ServiceCollectionExtensions
                 catch (Exception ex)
                 {
                     logger.LogWarning(ex, "Failed to initialize FileBackedIdempotencyStore; falling back to in-memory");
+                    diagnostics.RecordFallback(
+                        $"the file-backed idempotency store at {path ?? idemp.DataDirectory}",
+                        ex,
+                        "If FileHorizon is already running, stop it first: the file-backed store opens the file with FileShare.Read, so a second process cannot append to it.");
                 }
             }
             if (idemp.Enabled)
             {
-                logger.LogWarning("Idempotency is enabled but no durable store is configured; processed-file markers will NOT survive restarts");
+                if (diagnostics.Fallback is { } fallback)
+                {
+                    logger.LogWarning(
+                        "Idempotency is enabled and a durable store is configured ({Store}) but could not be opened; processed-file markers will NOT survive restarts",
+                        fallback.Store);
+                }
+                else
+                {
+                    logger.LogWarning("Idempotency is enabled but no durable store is configured; processed-file markers will NOT survive restarts");
+                }
             }
             return new Infrastructure.Idempotency.InMemoryIdempotencyStore();
         });

--- a/src/FileHorizon.Application/ServiceCollectionExtensions.cs
+++ b/src/FileHorizon.Application/ServiceCollectionExtensions.cs
@@ -176,10 +176,12 @@ public static class ServiceCollectionExtensions
                 catch (Exception ex)
                 {
                     logger.LogWarning(ex, "Failed to initialize FileBackedIdempotencyStore; falling back to in-memory");
+                    // Deliberately cause-agnostic: a running instance holding the file is the common
+                    // reason on Windows, but on Linux that open succeeds, so the hint must not claim it.
                     diagnostics.RecordFallback(
                         $"the file-backed idempotency store at {path ?? idemp.DataDirectory}",
                         ex,
-                        "If FileHorizon is already running, stop it first: the file-backed store opens the file with FileShare.Read, so a second process cannot append to it.");
+                        "If FileHorizon is already running, stop it first; otherwise check that the path exists and is writable.");
                 }
             }
             if (idemp.Enabled)

--- a/src/FileHorizon.Host/Commands/SeedIdempotencyCommand.cs
+++ b/src/FileHorizon.Host/Commands/SeedIdempotencyCommand.cs
@@ -41,9 +41,7 @@ public static class SeedIdempotencyCommand
         var store = services.GetRequiredService<IIdempotencyStore>();
         if (!dryRun && store is InMemoryIdempotencyStore)
         {
-            Console.Error.WriteLine(
-                "No durable idempotency store is configured, so seeded markers would be discarded when this process exits. " +
-                "Set Idempotency:DataDirectory (or enable Redis) and try again.");
+            Console.Error.WriteLine(DescribeUnusableStore(services));
             return 2;
         }
 
@@ -66,6 +64,27 @@ public static class SeedIdempotencyCommand
 
         Report(result.Value!, dryRun);
         return 0;
+    }
+
+    /// <summary>
+    /// Explains why seeding will not run. The store registration lands on the in-memory store for two
+    /// very different reasons - nothing durable configured, or something durable that would not open -
+    /// and only the first is a configuration problem, so pointing at config either way would send an
+    /// operator hunting through appsettings when the real fix is to stop the running service.
+    /// </summary>
+    private static string DescribeUnusableStore(IServiceProvider services)
+    {
+        const string consequence = "Seeded markers would be discarded when this process exits, so nothing was written.";
+
+        var fallback = services.GetRequiredService<IdempotencyStoreDiagnostics>().Fallback;
+        if (fallback is null)
+        {
+            return $"No durable idempotency store is configured. {consequence} " +
+                   "Set Idempotency:DataDirectory (or enable Redis) and try again.";
+        }
+
+        var message = $"Configuration selects {fallback.Store}, but it could not be opened: {fallback.Reason} {consequence}";
+        return fallback.Hint is null ? message : $"{message} {fallback.Hint}";
     }
 
     private static void Report(IdempotencySeedResult seed, bool dryRun)

--- a/src/FileHorizon.Host/Commands/SeedIdempotencyCommand.cs
+++ b/src/FileHorizon.Host/Commands/SeedIdempotencyCommand.cs
@@ -1,0 +1,146 @@
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Configuration;
+using FileHorizon.Application.Infrastructure.Idempotency;
+using FileHorizon.Application.Infrastructure.Polling;
+using Microsoft.Extensions.Options;
+
+namespace FileHorizon.Host.Commands;
+
+/// <summary>
+/// One-off maintenance command: marks everything currently present on a remote source as already
+/// transferred, so adopting a source with an existing backlog does not trigger a bulk transfer.
+/// Runs inside the normal host so it uses the same configuration, secrets and remote client as the
+/// poller, then exits without starting any background service.
+/// </summary>
+public static class SeedIdempotencyCommand
+{
+    public const string FlagName = "--seed-idempotency";
+
+    public static bool IsRequested(string[] args) => HasFlag(args, FlagName);
+
+    public static async Task<int> RunAsync(IServiceProvider services, string[] args, CancellationToken ct)
+    {
+        var sourceName = GetOption(args, "--source");
+        if (string.IsNullOrWhiteSpace(sourceName))
+        {
+            Console.Error.WriteLine($"Usage: {FlagName} --source <name> [--pattern <glob>] [--dry-run]");
+            return 2;
+        }
+
+        var dryRun = HasFlag(args, "--dry-run");
+        var patternOverride = GetOption(args, "--pattern");
+
+        var remoteSources = services.GetRequiredService<IOptions<RemoteFileSourcesOptions>>().Value;
+        var poller = ResolvePoller(services, remoteSources, sourceName, out var resolveError);
+        if (poller is null)
+        {
+            Console.Error.WriteLine(resolveError);
+            return 2;
+        }
+
+        var store = services.GetRequiredService<IIdempotencyStore>();
+        if (!dryRun && store is InMemoryIdempotencyStore)
+        {
+            Console.Error.WriteLine(
+                "No durable idempotency store is configured, so seeded markers would be discarded when this process exits. " +
+                "Set Idempotency:DataDirectory (or enable Redis) and try again.");
+            return 2;
+        }
+
+        var idempotency = services.GetRequiredService<IOptions<IdempotencyOptions>>().Value;
+        if (!idempotency.Enabled)
+        {
+            Console.Error.WriteLine(
+                "Warning: Idempotency:Enabled is false, so the pipeline will not consult these markers until it is enabled.");
+        }
+
+        var ttl = idempotency.TtlSeconds > 0 ? TimeSpan.FromSeconds(idempotency.TtlSeconds) : (TimeSpan?)null;
+        var request = new IdempotencySeedRequest(sourceName!, patternOverride, dryRun, ttl);
+
+        var result = await poller.SeedIdempotencyAsync(request, store, ct).ConfigureAwait(false);
+        if (result.IsFailure)
+        {
+            Console.Error.WriteLine($"Seeding failed: {result.Error}");
+            return 1;
+        }
+
+        Report(result.Value!, dryRun);
+        return 0;
+    }
+
+    private static void Report(IdempotencySeedResult seed, bool dryRun)
+    {
+        Console.WriteLine(dryRun
+            ? $"Dry run for source '{seed.SourceName}' (pattern {seed.Pattern}) - nothing was written."
+            : $"Seeded source '{seed.SourceName}' (pattern {seed.Pattern}).");
+        Console.WriteLine($"  scanned:       {seed.Scanned}");
+        if (!dryRun)
+        {
+            Console.WriteLine($"  marked:        {seed.Marked}");
+            Console.WriteLine($"  already known: {seed.AlreadyMarked}");
+        }
+
+        if (seed.SampleKeys.Count == 0) return;
+        Console.WriteLine($"  sample keys ({seed.SampleKeys.Count} of {seed.Scanned}):");
+        foreach (var key in seed.SampleKeys)
+        {
+            Console.WriteLine($"    {key}");
+        }
+    }
+
+    /// <summary>
+    /// Picks the poller owning the named source. The source name decides the protocol, so a typo
+    /// reports the available names rather than silently seeding nothing.
+    /// </summary>
+    private static RemotePollerBase? ResolvePoller(
+        IServiceProvider services,
+        RemoteFileSourcesOptions remoteSources,
+        string sourceName,
+        out string? error)
+    {
+        error = null;
+        var isSftp = remoteSources.Sftp.Any(s => string.Equals(s.Name, sourceName, StringComparison.OrdinalIgnoreCase));
+        var isFtp = remoteSources.Ftp.Any(s => string.Equals(s.Name, sourceName, StringComparison.OrdinalIgnoreCase));
+
+        if (!isSftp && !isFtp)
+        {
+            var known = remoteSources.Sftp.Select(s => s.Name)
+                .Concat(remoteSources.Ftp.Select(s => s.Name))
+                .Where(n => !string.IsNullOrWhiteSpace(n))
+                .ToList();
+            error = known.Count == 0
+                ? $"No remote source named '{sourceName}' is configured (RemoteFileSources has no entries)."
+                : $"No remote source named '{sourceName}' is configured. Known sources: {string.Join(", ", known)}.";
+            return null;
+        }
+
+        try
+        {
+            return isSftp
+                ? services.GetRequiredService<SftpPoller>()
+                : services.GetRequiredService<FtpPoller>();
+        }
+        catch (InvalidOperationException ex)
+        {
+            // The poller registrations throw when their feature flag is off.
+            var flag = isSftp ? "Features:EnableSftpPoller" : "Features:EnableFtpPoller";
+            error = $"Cannot seed '{sourceName}': {ex.Message}. Set {flag}=true and try again.";
+            return null;
+        }
+    }
+
+    private static bool HasFlag(string[] args, string name)
+        => args.Any(a => string.Equals(a, name, StringComparison.OrdinalIgnoreCase));
+
+    private static string? GetOption(string[] args, string name)
+    {
+        for (var i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase))
+            {
+                return args[i + 1];
+            }
+        }
+        return null;
+    }
+}

--- a/src/FileHorizon.Host/Program.cs
+++ b/src/FileHorizon.Host/Program.cs
@@ -124,7 +124,18 @@ var app = builder.Build();
 if (seedRequested)
 {
     // Maintenance path: seed idempotency markers and exit without starting any background service.
-    var seedExitCode = await SeedIdempotencyCommand.RunAsync(app.Services, args, CancellationToken.None);
+    int seedExitCode;
+    try
+    {
+        seedExitCode = await SeedIdempotencyCommand.RunAsync(app.Services, args, CancellationToken.None);
+    }
+    catch (OptionsValidationException ex)
+    {
+        // Options bound by the command are validated on first resolution. A one-off command should
+        // report unusable configuration as the documented exit 2, not as an unhandled crash.
+        Console.Error.WriteLine($"Configuration is invalid: {string.Join("; ", ex.Failures)}");
+        seedExitCode = 2;
+    }
     await app.DisposeAsync();
     return seedExitCode;
 }

--- a/src/FileHorizon.Host/Program.cs
+++ b/src/FileHorizon.Host/Program.cs
@@ -1,6 +1,7 @@
 using FileHorizon.Application;
 using FileHorizon.Application.Configuration;
 using FileHorizon.Application.Common.Telemetry;
+using FileHorizon.Host.Commands;
 using FileHorizon.Host.Telemetry;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Metrics;
@@ -9,7 +10,10 @@ using OpenTelemetry.Trace;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Exporter.Prometheus;
 
-var builder = WebApplication.CreateBuilder(args);
+// Seeding flags are not configuration keys; keep them away from the command-line config provider,
+// which rejects bare switches. Configuration still comes from appsettings and the environment.
+var seedRequested = SeedIdempotencyCommand.IsRequested(args);
+var builder = WebApplication.CreateBuilder(seedRequested ? [] : args);
 
 builder.Services.AddApplicationServices();
 builder.Services.Configure<PollingOptions>(builder.Configuration.GetSection(PollingOptions.SectionName));
@@ -117,6 +121,14 @@ builder.Services.AddOpenTelemetry()
 
 var app = builder.Build();
 
+if (seedRequested)
+{
+    // Maintenance path: seed idempotency markers and exit without starting any background service.
+    var seedExitCode = await SeedIdempotencyCommand.RunAsync(app.Services, args, CancellationToken.None);
+    await app.DisposeAsync();
+    return seedExitCode;
+}
+
 app.MapHealthChecks("/health");
 
 // Expose Prometheus metrics scraping endpoint if enabled
@@ -126,3 +138,5 @@ if (telemetryOptions.EnableMetrics && telemetryOptions.EnablePrometheus)
 }
 
 app.Run();
+
+return 0;

--- a/test/FileHorizon.Application.Tests/IdempotencySeedTests.cs
+++ b/test/FileHorizon.Application.Tests/IdempotencySeedTests.cs
@@ -1,0 +1,318 @@
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Common;
+using FileHorizon.Application.Configuration;
+using FileHorizon.Application.Infrastructure.Idempotency;
+using FileHorizon.Application.Infrastructure.Polling;
+using FileHorizon.Application.Models;
+using FileHorizon.Application.Tests.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+
+namespace FileHorizon.Application.Tests;
+
+public class IdempotencySeedTests
+{
+    private const string SourceName = "s1";
+    private const string Host = "sftp.example.com";
+    private const int Port = 22;
+
+    [Fact]
+    public async Task SeedIdempotencyAsync_ProducesTheSameKeyAsTheTransferPath()
+    {
+        // The whole point of seeding is that a seeded marker suppresses the file the poller would
+        // otherwise dispatch, so the two code paths must derive byte-identical keys.
+        var file = new FakeFile("/upload/a.zip", 1234, new DateTimeOffset(2026, 7, 14, 9, 13, 22, TimeSpan.Zero));
+        var queue = new TestQueue();
+        var poller = CreatePoller(queue, file, minStableSeconds: 0);
+
+        var seed = await poller.SeedIdempotencyAsync(
+            new IdempotencySeedRequest(SourceName, DryRun: true), new InMemoryIdempotencyStore(), CancellationToken.None);
+        Assert.True(seed.IsSuccess);
+        var seededKey = Assert.Single(seed.Value!.SampleKeys);
+
+        await poller.PollAsync(CancellationToken.None);
+        var dispatched = Assert.Single(queue.TryDrain(10));
+        var transferKey = FileIdentity.BuildIdempotencyKey(dispatched.Metadata);
+
+        Assert.Equal(transferKey, seededKey);
+    }
+
+    [Fact]
+    public async Task SeedIdempotencyAsync_MarksScannedFilesAsProcessed()
+    {
+        var file = new FakeFile("/upload/a.zip", 10, DateTimeOffset.UtcNow.AddHours(-1));
+        var queue = new TestQueue();
+        var poller = CreatePoller(queue, file, minStableSeconds: 0);
+        var store = new InMemoryIdempotencyStore();
+
+        var seed = await poller.SeedIdempotencyAsync(
+            new IdempotencySeedRequest(SourceName), store, CancellationToken.None);
+
+        Assert.True(seed.IsSuccess);
+        Assert.Equal(1, seed.Value!.Scanned);
+        Assert.Equal(1, seed.Value.Marked);
+        Assert.Equal(0, seed.Value.AlreadyMarked);
+
+        // A subsequent poll produces the key the orchestrator would look up; it must already be present.
+        await poller.PollAsync(CancellationToken.None);
+        var dispatched = Assert.Single(queue.TryDrain(10));
+        Assert.True(await store.IsProcessedAsync(FileIdentity.BuildIdempotencyKey(dispatched.Metadata), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SeedIdempotencyAsync_RunTwice_ReportsSecondPassAsAlreadyMarked()
+    {
+        var file = new FakeFile("/upload/a.zip", 10, DateTimeOffset.UtcNow.AddHours(-1));
+        var poller = CreatePoller(new TestQueue(), file, minStableSeconds: 0);
+        var store = new InMemoryIdempotencyStore();
+
+        await poller.SeedIdempotencyAsync(new IdempotencySeedRequest(SourceName), store, CancellationToken.None);
+        var second = await poller.SeedIdempotencyAsync(new IdempotencySeedRequest(SourceName), store, CancellationToken.None);
+
+        Assert.True(second.IsSuccess);
+        Assert.Equal(0, second.Value!.Marked);
+        Assert.Equal(1, second.Value.AlreadyMarked);
+    }
+
+    [Fact]
+    public async Task SeedIdempotencyAsync_DryRun_WritesNothing()
+    {
+        var file = new FakeFile("/upload/a.zip", 10, DateTimeOffset.UtcNow.AddHours(-1));
+        var poller = CreatePoller(new TestQueue(), file, minStableSeconds: 0);
+        var store = new InMemoryIdempotencyStore();
+
+        var seed = await poller.SeedIdempotencyAsync(
+            new IdempotencySeedRequest(SourceName, DryRun: true), store, CancellationToken.None);
+
+        Assert.True(seed.IsSuccess);
+        Assert.Equal(1, seed.Value!.Scanned);
+        Assert.Equal(0, seed.Value.Marked);
+        Assert.False(await store.IsProcessedAsync(seed.Value.SampleKeys[0], CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SeedIdempotencyAsync_PatternOverride_LimitsScope()
+    {
+        var files = new[]
+        {
+            new FakeFile("/upload/a.zip", 10, DateTimeOffset.UtcNow.AddHours(-1)),
+            new FakeFile("/upload/b.txt", 10, DateTimeOffset.UtcNow.AddHours(-1))
+        };
+        var poller = CreatePoller(new TestQueue(), files, minStableSeconds: 0, pattern: "*");
+        var store = new InMemoryIdempotencyStore();
+
+        var seed = await poller.SeedIdempotencyAsync(
+            new IdempotencySeedRequest(SourceName, PatternOverride: "*.zip"), store, CancellationToken.None);
+
+        Assert.True(seed.IsSuccess);
+        Assert.Equal(1, seed.Value!.Scanned);
+        Assert.Equal("*.zip", seed.Value.Pattern);
+        Assert.Contains("a.zip", seed.Value.SampleKeys[0]);
+    }
+
+    [Fact]
+    public async Task SeedIdempotencyAsync_KeyHasTheDocumentedShape()
+    {
+        // Pins the on-disk marker format. Note the mtime renders with a "+00:00" offset rather than "Z",
+        // because FileMetadata.LastModifiedUtc is a DateTimeOffset.
+        var mtime = new DateTimeOffset(2026, 7, 14, 9, 13, 22, TimeSpan.Zero);
+        var poller = CreatePoller(new TestQueue(), new FakeFile("/upload/a.zip", 1234, mtime), minStableSeconds: 0);
+
+        var seed = await poller.SeedIdempotencyAsync(
+            new IdempotencySeedRequest(SourceName, DryRun: true), new InMemoryIdempotencyStore(), CancellationToken.None);
+
+        Assert.True(seed.IsSuccess);
+        Assert.Equal(
+            "fh:idemp:v2:sftp://sftp.example.com:22/upload/a.zip|1234|2026-07-14T09:13:22.0000000+00:00",
+            seed.Value!.SampleKeys[0]);
+    }
+
+    [Fact]
+    public async Task SeedIdempotencyAsync_SkipsDirectories()
+    {
+        var entries = new[]
+        {
+            new FakeFile("/upload/nested", 0, DateTimeOffset.UtcNow.AddHours(-1), IsDir: true),
+            new FakeFile("/upload/a.zip", 10, DateTimeOffset.UtcNow.AddHours(-1))
+        };
+        var poller = CreatePoller(new TestQueue(), entries, minStableSeconds: 0);
+        var store = new InMemoryIdempotencyStore();
+
+        var seed = await poller.SeedIdempotencyAsync(
+            new IdempotencySeedRequest(SourceName), store, CancellationToken.None);
+
+        Assert.True(seed.IsSuccess);
+        Assert.Equal(1, seed.Value!.Scanned);
+    }
+
+    [Fact]
+    public async Task SeedIdempotencyAsync_UnknownSource_Fails()
+    {
+        var file = new FakeFile("/upload/a.zip", 10, DateTimeOffset.UtcNow.AddHours(-1));
+        var poller = CreatePoller(new TestQueue(), file, minStableSeconds: 0);
+
+        var seed = await poller.SeedIdempotencyAsync(
+            new IdempotencySeedRequest("nope"), new InMemoryIdempotencyStore(), CancellationToken.None);
+
+        Assert.True(seed.IsFailure);
+        Assert.Contains("nope", seed.Error.Message);
+    }
+
+    [Fact]
+    public async Task SeedIdempotencyAsync_ConnectFailure_ReturnsFailure()
+    {
+        var file = new FakeFile("/upload/a.zip", 10, DateTimeOffset.UtcNow.AddHours(-1));
+        var poller = CreatePoller(new TestQueue(), [file], minStableSeconds: 0, failConnect: true);
+
+        var seed = await poller.SeedIdempotencyAsync(
+            new IdempotencySeedRequest(SourceName), new InMemoryIdempotencyStore(), CancellationToken.None);
+
+        Assert.True(seed.IsFailure);
+        Assert.Equal("Idempotency.SeedFailed", seed.Error.Code);
+    }
+
+    private static TestRemotePoller CreatePoller(
+        TestQueue queue,
+        FakeFile file,
+        int minStableSeconds) => CreatePoller(queue, [file], minStableSeconds);
+
+    private static TestRemotePoller CreatePoller(
+        TestQueue queue,
+        FakeFile[] files,
+        int minStableSeconds,
+        string pattern = "*.zip",
+        bool failConnect = false)
+    {
+        var options = new OptionsMonitorStub<RemoteFileSourcesOptions>(new RemoteFileSourcesOptions
+        {
+            Sftp =
+            [
+                new SftpSourceOptions
+                {
+                    Name = SourceName,
+                    Host = Host,
+                    Port = Port,
+                    RemotePath = "/upload",
+                    Pattern = pattern,
+                    Recursive = false,
+                    MinStableSeconds = minStableSeconds,
+                    Username = "u",
+                    PasswordSecretRef = "p"
+                }
+            ]
+        });
+        return new TestRemotePoller(queue, options, _ => new FakeRemoteClient(Host, Port, files, failConnect));
+    }
+
+    private sealed record FakeFile(string FullPath, long Size, DateTimeOffset LastWrite, bool IsDir = false);
+
+    private sealed class FakeRemoteFileInfo(FakeFile file) : IRemoteFileInfo
+    {
+        public string FullPath { get; } = file.FullPath;
+        public string Name { get; } = Path.GetFileName(file.FullPath);
+        public long Size { get; } = file.Size;
+        public DateTimeOffset LastWriteTimeUtc { get; } = file.LastWrite;
+        public bool IsDirectory { get; } = file.IsDir;
+    }
+
+    private sealed class FakeRemoteClient(string host, int port, FakeFile[] files, bool failConnect) : IRemoteFileClient
+    {
+        public ProtocolType Protocol => ProtocolType.Sftp;
+        public string Host { get; } = host;
+        public int Port { get; } = port;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public Task ConnectAsync(CancellationToken ct)
+            => failConnect ? throw new InvalidOperationException("connect fail") : Task.CompletedTask;
+
+        public async IAsyncEnumerable<IRemoteFileInfo> ListFilesAsync(
+            string path, bool recursive, string pattern,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            foreach (var f in files)
+            {
+                // Mirror the real client: the glob is applied to the bare file name, directories pass through.
+                if (!f.IsDir && !Matches(Path.GetFileName(f.FullPath), pattern)) continue;
+                yield return new FakeRemoteFileInfo(f);
+                await Task.Yield();
+            }
+        }
+
+        private static bool Matches(string name, string pattern)
+        {
+            if (pattern is "*" or "*.*") return true;
+            if (pattern.StartsWith("*.", StringComparison.Ordinal))
+            {
+                return name.EndsWith(pattern[1..], StringComparison.OrdinalIgnoreCase);
+            }
+            return string.Equals(name, pattern, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public Task<IRemoteFileInfo?> GetFileInfoAsync(string fullPath, CancellationToken ct)
+            => Task.FromResult<IRemoteFileInfo?>(null);
+
+        public Task DeleteAsync(string fullPath, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private sealed class TestQueue : IFileEventQueue
+    {
+        private readonly ConcurrentQueue<FileEvent> _events = new();
+
+        public Task<Result> EnqueueAsync(FileEvent fileEvent, CancellationToken ct)
+        {
+            _events.Enqueue(fileEvent);
+            return Task.FromResult(Result.Success());
+        }
+
+        public IAsyncEnumerable<FileEvent> DequeueAsync(CancellationToken ct) => Empty();
+
+        private static async IAsyncEnumerable<FileEvent> Empty()
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public IReadOnlyCollection<FileEvent> TryDrain(int maxCount)
+        {
+            var list = new List<FileEvent>();
+            while (list.Count < maxCount && _events.TryDequeue(out var ev)) list.Add(ev);
+            return list;
+        }
+    }
+
+    private sealed class TestRemotePoller : RemotePollerBase
+    {
+        private readonly List<IRemoteFileSourceDescriptor> _sources;
+        // object rather than IRemoteFileSourceDescriptor: the descriptor interface is protected on the
+        // base, so the enclosing test class cannot name it.
+        private readonly Func<object, IRemoteFileClient> _clientFactory;
+
+        internal TestRemotePoller(
+            IFileEventQueue queue,
+            IOptionsMonitor<RemoteFileSourcesOptions> options,
+            Func<object, IRemoteFileClient> clientFactory)
+            : base(queue, options, NullLogger<TestRemotePoller>.Instance)
+        {
+            _clientFactory = clientFactory;
+            _sources = [.. options.CurrentValue.Sftp.Where(s => s.Enabled).Select(s => (IRemoteFileSourceDescriptor)new Src(s))];
+        }
+
+        protected override List<IRemoteFileSourceDescriptor> GetEnabledSources() => _sources;
+        protected override IRemoteFileClient CreateClient(IRemoteFileSourceDescriptor source) => _clientFactory(source);
+        protected override ProtocolType MapProtocolType(ProtocolType protocol) => protocol;
+
+        private sealed class Src(SftpSourceOptions o) : IRemoteFileSourceDescriptor
+        {
+            public string Name => o.Name;
+            public string RemotePath => o.RemotePath;
+            public string Pattern => o.Pattern;
+            public bool Recursive => o.Recursive;
+            public int MinStableSeconds => o.MinStableSeconds;
+            public string? DestinationPath => o.DestinationPath;
+            public string Host => o.Host;
+            public int Port => o.Port;
+            public bool DeleteAfterTransfer => o.DeleteAfterTransfer;
+        }
+    }
+}

--- a/test/FileHorizon.Application.Tests/ServiceRegistrationTests.cs
+++ b/test/FileHorizon.Application.Tests/ServiceRegistrationTests.cs
@@ -110,6 +110,44 @@ public class ServiceRegistrationTests
     }
 
     [Fact]
+    public void IdempotencyStore_Should_Record_No_Fallback_When_Nothing_Configured()
+    {
+        // Nothing durable was asked for, so there is no failure to report - only the absence of config.
+        using var sp = BuildServiceProvider();
+        Assert.IsType<Infrastructure.Idempotency.InMemoryIdempotencyStore>(sp.GetRequiredService<IIdempotencyStore>());
+        Assert.Null(sp.GetRequiredService<Infrastructure.Idempotency.IdempotencyStoreDiagnostics>().Fallback);
+    }
+
+    [Fact]
+    public void IdempotencyStore_Should_Record_Fallback_Cause_When_FileBacked_Store_Is_Locked()
+    {
+        // Reproduces "the service is still running": the marker file is already held for append with
+        // FileShare.Read, so the store cannot be constructed and the registration falls back silently.
+        var dataDir = Path.Combine(Path.GetTempPath(), "fh-idemp-di-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dataDir);
+        var path = Path.Combine(dataDir, Infrastructure.Idempotency.FileBackedIdempotencyStore.DefaultFileName);
+        try
+        {
+            using (new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read))
+            {
+                using var sp = BuildServiceProviderWithIdempotency(new IdempotencyOptions { Enabled = true, DataDirectory = dataDir });
+
+                Assert.IsType<Infrastructure.Idempotency.InMemoryIdempotencyStore>(sp.GetRequiredService<IIdempotencyStore>());
+
+                var fallback = sp.GetRequiredService<Infrastructure.Idempotency.IdempotencyStoreDiagnostics>().Fallback;
+                Assert.NotNull(fallback);
+                Assert.Contains(path, fallback!.Store);
+                Assert.False(string.IsNullOrWhiteSpace(fallback.Reason));
+                Assert.NotNull(fallback.Hint);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(dataDir, true); } catch { }
+        }
+    }
+
+    [Fact]
     public void IFileProcessor_Should_Be_Orchestrator_By_Default()
     {
         using var sp = BuildServiceProvider();

--- a/test/FileHorizon.Application.Tests/ServiceRegistrationTests.cs
+++ b/test/FileHorizon.Application.Tests/ServiceRegistrationTests.cs
@@ -119,10 +119,38 @@ public class ServiceRegistrationTests
     }
 
     [Fact]
-    public void IdempotencyStore_Should_Record_Fallback_Cause_When_FileBacked_Store_Is_Locked()
+    public void IdempotencyStore_Should_Record_Fallback_Cause_When_Durable_Store_Cannot_Be_Opened()
     {
-        // Reproduces "the service is still running": the marker file is already held for append with
-        // FileShare.Read, so the store cannot be constructed and the registration falls back silently.
+        // A directory sitting where the marker file belongs fails construction identically on every
+        // platform, unlike a file lock, which only Windows enforces.
+        var dataDir = Path.Combine(Path.GetTempPath(), "fh-idemp-di-tests", Guid.NewGuid().ToString("N"));
+        var path = Path.Combine(dataDir, Infrastructure.Idempotency.FileBackedIdempotencyStore.DefaultFileName);
+        Directory.CreateDirectory(path);
+        try
+        {
+            using var sp = BuildServiceProviderWithIdempotency(new IdempotencyOptions { Enabled = true, DataDirectory = dataDir });
+
+            Assert.IsType<Infrastructure.Idempotency.InMemoryIdempotencyStore>(sp.GetRequiredService<IIdempotencyStore>());
+
+            var fallback = sp.GetRequiredService<Infrastructure.Idempotency.IdempotencyStoreDiagnostics>().Fallback;
+            Assert.NotNull(fallback);
+            Assert.Contains(path, fallback!.Store);
+            Assert.False(string.IsNullOrWhiteSpace(fallback.Reason));
+            Assert.NotNull(fallback.Hint);
+        }
+        finally
+        {
+            try { Directory.Delete(dataDir, true); } catch { }
+        }
+    }
+
+    // .NET enforces FileShare on Windows only; on Unix a second writer opens the file happily, so a lock
+    // cannot be used to detect a running instance there. See the README note under seeding.
+    [WindowsOnlyFact("FileShare is enforced on Windows only.")]
+    public void IdempotencyStore_Should_Record_Fallback_Cause_When_Marker_File_Is_Locked()
+    {
+        // Reproduces "the service is still running" on Windows: the marker file is already held for
+        // append with FileShare.Read, so the store cannot be constructed and the registration falls back.
         var dataDir = Path.Combine(Path.GetTempPath(), "fh-idemp-di-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dataDir);
         var path = Path.Combine(dataDir, Infrastructure.Idempotency.FileBackedIdempotencyStore.DefaultFileName);
@@ -137,8 +165,6 @@ public class ServiceRegistrationTests
                 var fallback = sp.GetRequiredService<Infrastructure.Idempotency.IdempotencyStoreDiagnostics>().Fallback;
                 Assert.NotNull(fallback);
                 Assert.Contains(path, fallback!.Store);
-                Assert.False(string.IsNullOrWhiteSpace(fallback.Reason));
-                Assert.NotNull(fallback.Hint);
             }
         }
         finally

--- a/test/FileHorizon.Application.Tests/WindowsOnlyFactAttribute.cs
+++ b/test/FileHorizon.Application.Tests/WindowsOnlyFactAttribute.cs
@@ -1,0 +1,17 @@
+namespace FileHorizon.Application.Tests;
+
+/// <summary>
+/// A <see cref="FactAttribute"/> that reports as skipped off Windows, for behaviour the OS itself
+/// decides. xunit v2 has no runtime skip, and returning early would report a pass for a test that
+/// never ran.
+/// </summary>
+public sealed class WindowsOnlyFactAttribute : FactAttribute
+{
+    public WindowsOnlyFactAttribute(string reason)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Skip = reason;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #34

## What

Adds a maintenance flag to `FileHorizon.Host` that marks everything currently present on a remote source as already transferred, so a source with an existing backlog can be adopted without triggering a bulk transfer.

```
FileHorizon.Host.exe --seed-idempotency --source PartnerSftp [--pattern "*.zip"] [--dry-run]
```

It lists the source, writes a marker per matching file and exits without starting any background service. Historical files can then be fetched by other means; only files arriving afterwards go through the pipeline.

## Why it lives in the host, not a separate CLI

The correctness requirement is that a seeded key is byte-identical to the key the poller would produce. A separate CLI would need its own configuration loading, secret resolution and SFTP wiring, and every one of those is a chance to drift. Running inside the host reuses the real `appsettings.json`, `RemoteFileSourcesOptions`, secret resolution, host key validation and remote client.

Two further guards against drift:

- Markers are written through `IIdempotencyStore.TryMarkProcessedAsync`, never composed as JSON, so the stored format is whatever the configured store uses and Redis works unchanged.
- `FileMetadata` construction is now a shared private helper used by both `EnqueueEventAsync` and the seeder, so the identity key and mtime conversion cannot diverge.

## Behaviour

- `--source` is required; the name selects the protocol, and an unknown name lists the configured sources rather than silently seeding nothing.
- `--pattern` overrides the source's `Pattern` for partial seeding; listing otherwise goes through the existing `ListFilesAsync`, so `Pattern`/`Recursive` semantics are identical to polling.
- `--dry-run` reports counts and sample keys without writing.
- Seeding refuses to run against the in-memory store, where markers would be discarded on exit.
- Exit codes: `0` success, `1` seeding failed, `2` bad arguments or unusable configuration.
- Seeding flags are withheld from the command-line configuration provider, which rejects bare switches.
- A partial run is safe to repeat: markers written before a failure are durable and correct, and a re-run reports them as already marked.

## Tests

`IdempotencySeedTests` covers:

- **key parity** - a seeded key equals the key derived from the `FileEvent` the poller dispatches for the same file (the acceptance criterion from the issue);
- the exact marker format, pinned as a literal;
- markers being visible to `IsProcessedAsync` after seeding;
- dry-run writing nothing, pattern override, re-run accounting, directory skipping, unknown source, connect failure.

Full suite: 229 passed, 3 pre-existing skips.

## Not covered

No live SFTP round-trip - Docker was unavailable on the machine this was written on, so the real `SftpPoller.CreateClient` path (secret resolution plus SSH.NET) was exercised only through the existing poller code it shares, not end to end. The CLI argument, source-resolution and early-exit paths were smoke-tested against the real host.

## Note for anyone who has hand-written markers

The mtime in a key renders with a `+00:00` offset, not `Z`, because `FileMetadata.LastModifiedUtc` is a `DateTimeOffset`. There is now a test pinning this, and the README documents it.