### PR TITLE
feat(sftp): allow pinning multiple host key fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Example `appsettings.json` excerpt:
         "PrivateKeySecretRef": "secrets:sftp-key",
         "PrivateKeyPassphraseSecretRef": "secrets:sftp-key-pass",
         "HostKeyFingerprint": "SHA256:...base64...",
+        "HostKeyFingerprints": ["SHA256:...ed25519...", "SHA256:...rsa..."],
         "StrictHostKey": true,
         "MinStableSeconds": 8,
         "Enabled": true
@@ -148,6 +149,34 @@ Validation rules enforced at startup:
 - `Port` must be > 0.
 - Appropriate credential secret(s) must be present (username/password or key for SFTP; username/password for FTP).
 - `MinStableSeconds` must be >= 0.
+- Every configured host key fingerprint must be a recognised format (see below).
+- `StrictHostKey: true` requires at least one fingerprint, otherwise every connection would be rejected.
+
+### SFTP Host Key Verification
+
+The server's host key is checked against the fingerprints pinned in configuration. Three formats are accepted:
+
+| Format | Example |
+| ------ | ------- |
+| OpenSSH SHA256 | `SHA256:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU` |
+| Bare base64 SHA256 (padded or unpadded) | `47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU` |
+| Legacy MD5 colon hex | `16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48` |
+
+Get a server's fingerprint with `ssh-keyscan -t ed25519 sftp.partner.net | ssh-keygen -lf -`.
+
+Use `HostKeyFingerprint` for a single key. Use `HostKeyFingerprints` to pin several — the presented key is trusted when it matches **any** entry. Both properties may be set at once; the union is accepted, and formats can be mixed within a list. Pinning several keys covers two common cases:
+
+- **Multiple host key algorithms.** A server offering both ed25519 and RSA may present either, depending on what gets negotiated. Pinning only one means an algorithm change (server reconfiguration, library upgrade) breaks the connection.
+- **Key rotation.** Pin the old and new keys together for the duration of the cutover, then remove the old one.
+
+Behaviour when a key does not match, or when none is configured, is governed by `StrictHostKey`:
+
+| `StrictHostKey` | No fingerprints configured | Fingerprints configured |
+| --------------- | -------------------------- | ----------------------- |
+| `false` (default) | Connect, log a warning with the presented fingerprint | Connect only on match; reject otherwise |
+| `true` | Reject (and fail startup validation) | Connect only on match; reject otherwise |
+
+A delimited list in the singular `HostKeyFingerprint` property (for example two fingerprints separated by a comma) is **not** supported and is rejected at startup — use `HostKeyFingerprints`.
 
 ### Secrets
 

--- a/src/FileHorizon.Application/Abstractions/ISftpClientFactory.cs
+++ b/src/FileHorizon.Application/Abstractions/ISftpClientFactory.cs
@@ -15,8 +15,8 @@ public interface ISftpClientFactory
 {
     /// <summary>
     /// Create an SFTP client using either password or private key authentication. One of password or privateKeyPem must be provided.
-    /// When <paramref name="hostKeyFingerprint"/> is set, the server host key must match it or the connection is rejected.
-    /// When <paramref name="strictHostKey"/> is true and no fingerprint is configured, the connection is rejected.
+    /// When <paramref name="hostKeyFingerprints"/> is non-empty, the server host key must match at least one entry or the connection is rejected.
+    /// When <paramref name="strictHostKey"/> is true and no fingerprints are configured, the connection is rejected.
     /// </summary>
-    ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase, string? hostKeyFingerprint = null, bool strictHostKey = false);
+    ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase, IReadOnlyList<string>? hostKeyFingerprints = null, bool strictHostKey = false);
 }

--- a/src/FileHorizon.Application/Configuration/HostKeyFingerprintSet.cs
+++ b/src/FileHorizon.Application/Configuration/HostKeyFingerprintSet.cs
@@ -1,0 +1,65 @@
+namespace FileHorizon.Application.Configuration;
+
+/// <summary>
+/// Helpers for combining the singular and plural host key fingerprint configuration properties
+/// into the single list the connection code works with.
+/// </summary>
+public static class HostKeyFingerprintSet
+{
+    /// <summary>
+    /// Combine a singular fingerprint property with a list property into one de-duplicated list,
+    /// trimming whitespace and dropping blank entries. Order is preserved with the singular value first.
+    /// </summary>
+    public static IReadOnlyList<string> Combine(string? single, IEnumerable<string>? many)
+    {
+        List<string>? result = null;
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void Add(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var trimmed = value.Trim();
+            if (!seen.Add(trimmed)) return;
+            (result ??= []).Add(trimmed);
+        }
+
+        Add(single);
+        if (many is not null)
+        {
+            foreach (var value in many) Add(value);
+        }
+
+        return (IReadOnlyList<string>?)result ?? [];
+    }
+
+    /// <summary>
+    /// Shape check for a configured fingerprint, so a typo fails at startup rather than silently
+    /// rejecting every connection later. Accepts OpenSSH SHA256 ("SHA256:&lt;base64&gt;"), bare
+    /// base64 SHA256, and legacy MD5 colon-separated hex.
+    /// </summary>
+    public static bool IsWellFormed(string fingerprint)
+    {
+        if (string.IsNullOrWhiteSpace(fingerprint)) return false;
+        var value = fingerprint.Trim();
+
+        // Legacy MD5: 16 colon-separated hex pairs.
+        if (value.Contains(':') && !value.StartsWith("SHA256:", StringComparison.OrdinalIgnoreCase))
+        {
+            var parts = value.Split(':');
+            return parts.Length == 16 && Array.TrueForAll(parts, p => p.Length == 2 && IsHex(p));
+        }
+
+        if (value.StartsWith("SHA256:", StringComparison.OrdinalIgnoreCase))
+        {
+            value = value["SHA256:".Length..];
+        }
+
+        // SHA256 is 32 bytes -> 43 unpadded / 44 padded base64 characters.
+        var unpadded = value.TrimEnd('=');
+        if (unpadded.Length != 43) return false;
+        return Convert.TryFromBase64String(unpadded + "=", new byte[32], out var written) && written == 32;
+    }
+
+    private static bool IsHex(string pair) =>
+        Uri.IsHexDigit(pair[0]) && Uri.IsHexDigit(pair[1]);
+}

--- a/src/FileHorizon.Application/Configuration/RemoteFileSourcesOptionsValidator.cs
+++ b/src/FileHorizon.Application/Configuration/RemoteFileSourcesOptionsValidator.cs
@@ -105,9 +105,17 @@ public sealed class RemoteFileSourcesOptionsValidator : IValidateOptions<RemoteF
                 {
                     errors.Add($"{prefix}: PrivateKeyPassphraseSecretRef specified but PrivateKeySecretRef is missing.");
                 }
-                if (sftp.StrictHostKey && string.IsNullOrWhiteSpace(sftp.HostKeyFingerprint))
+                var fingerprints = sftp.AllHostKeyFingerprints();
+                if (sftp.StrictHostKey && fingerprints.Count == 0)
                 {
-                    errors.Add($"{prefix}: StrictHostKey is enabled but HostKeyFingerprint is not configured; connections would always be rejected.");
+                    errors.Add($"{prefix}: StrictHostKey is enabled but no HostKeyFingerprint/HostKeyFingerprints are configured; connections would always be rejected.");
+                }
+                foreach (var fingerprint in fingerprints)
+                {
+                    if (!HostKeyFingerprintSet.IsWellFormed(fingerprint))
+                    {
+                        errors.Add($"{prefix}: Host key fingerprint '{fingerprint}' is not a recognised format; expected OpenSSH SHA256 ('SHA256:<base64>'), bare base64 SHA256, or legacy MD5 colon-separated hex.");
+                    }
                 }
             }
         }

--- a/src/FileHorizon.Application/Configuration/SftpSourceOptions.cs
+++ b/src/FileHorizon.Application/Configuration/SftpSourceOptions.cs
@@ -21,12 +21,33 @@ public sealed class SftpSourceOptions
     /// bare base64 SHA256, or legacy MD5 colon-separated hex. When set, connections to servers whose
     /// host key does not match are rejected.
     /// </summary>
+    /// <remarks>
+    /// Retained for backwards compatibility and for the common single-key case. To pin several keys
+    /// (for example one per host key algorithm, or an outgoing and incoming key during rotation) use
+    /// <see cref="HostKeyFingerprints"/>. Both properties may be set; the union is accepted.
+    /// </remarks>
     public string? HostKeyFingerprint { get; set; }
     /// <summary>
-    /// If true, require a matching <see cref="HostKeyFingerprint"/> and refuse to connect when none is
-    /// configured. If false (default), an unpinned host key is accepted with a warning logged.
+    /// Additional accepted server host key fingerprints, in the same formats as
+    /// <see cref="HostKeyFingerprint"/>. A presented host key is trusted when it matches any entry.
+    /// </summary>
+    /// <remarks>
+    /// Useful when a server offers multiple host key algorithms (e.g. ed25519 and RSA) and the
+    /// negotiated one may vary, or to trust both the old and the new key across a rotation window.
+    /// </remarks>
+    public IList<string> HostKeyFingerprints { get; set; } = [];
+    /// <summary>
+    /// If true, require a match against the configured fingerprints and refuse to connect when none
+    /// are configured. If false (default), an unpinned host key is accepted with a warning logged.
     /// </summary>
     public bool StrictHostKey { get; set; } = false;
+
+    /// <summary>
+    /// The union of <see cref="HostKeyFingerprint"/> and <see cref="HostKeyFingerprints"/>,
+    /// trimmed and with blank entries removed.
+    /// </summary>
+    public IReadOnlyList<string> AllHostKeyFingerprints() =>
+        HostKeyFingerprintSet.Combine(HostKeyFingerprint, HostKeyFingerprints);
     public string? DestinationPath { get; set; }
     public bool CreateDestinationDirectories { get; set; } = true;
     /// <summary>

--- a/src/FileHorizon.Application/Infrastructure/FileProcessing/FileProcessingOrchestrator.cs
+++ b/src/FileHorizon.Application/Infrastructure/FileProcessing/FileProcessingOrchestrator.cs
@@ -414,7 +414,7 @@ public sealed class FileProcessingOrchestrator(
                 password,
                 null,
                 null,
-                hostKeyFingerprint: src.HostKeyFingerprint,
+                hostKeyFingerprints: src.AllHostKeyFingerprints(),
                 strictHostKey: src.StrictHostKey
             );
             await client.ConnectAsync(ct).ConfigureAwait(false);

--- a/src/FileHorizon.Application/Infrastructure/Polling/SftpPoller.cs
+++ b/src/FileHorizon.Application/Infrastructure/Polling/SftpPoller.cs
@@ -58,7 +58,7 @@ public sealed class SftpPoller(IFileEventQueue queue,
             password,
             privateKey,
             passphrase,
-            s.HostKeyFingerprint,
+            s.AllHostKeyFingerprints(),
             s.StrictHostKey);
     }
 

--- a/src/FileHorizon.Application/Infrastructure/Processing/SftpFileContentReader.cs
+++ b/src/FileHorizon.Application/Infrastructure/Processing/SftpFileContentReader.cs
@@ -50,7 +50,7 @@ public sealed class SftpFileContentReader : IFileContentReader
             return Result<FileAttributesInfo>.Failure(Error.Validation.Invalid("Invalid SFTP file reference; host/port/path missing"));
         }
         var creds = await ResolveCredentialsAsync(file.SourceName, host, port, ct).ConfigureAwait(false);
-        await using var client = _factory.Create(host, port, creds.Username, creds.Password, creds.PrivateKeyPem, creds.PrivateKeyPassphrase, creds.HostKeyFingerprint, creds.StrictHostKey);
+        await using var client = _factory.Create(host, port, creds.Username, creds.Password, creds.PrivateKeyPem, creds.PrivateKeyPassphrase, creds.HostKeyFingerprints, creds.StrictHostKey);
         try
         {
             await client.ConnectAsync(ct).ConfigureAwait(false);
@@ -76,7 +76,7 @@ public sealed class SftpFileContentReader : IFileContentReader
         }
         var creds = await ResolveCredentialsAsync(file.SourceName, host, port, ct).ConfigureAwait(false);
         // REMOVE await using (must keep client alive for stream lifetime)
-        var client = _factory.Create(host, port, creds.Username, creds.Password, creds.PrivateKeyPem, creds.PrivateKeyPassphrase, creds.HostKeyFingerprint, creds.StrictHostKey);
+        var client = _factory.Create(host, port, creds.Username, creds.Password, creds.PrivateKeyPem, creds.PrivateKeyPassphrase, creds.HostKeyFingerprints, creds.StrictHostKey);
         try
         {
             await client.ConnectAsync(ct).ConfigureAwait(false);
@@ -92,7 +92,7 @@ public sealed class SftpFileContentReader : IFileContentReader
         }
     }
 
-    private async Task<(string Username, string? Password, string? PrivateKeyPem, string? PrivateKeyPassphrase, string? HostKeyFingerprint, bool StrictHostKey)>
+    private async Task<(string Username, string? Password, string? PrivateKeyPem, string? PrivateKeyPassphrase, IReadOnlyList<string>? HostKeyFingerprints, bool StrictHostKey)>
         ResolveCredentialsAsync(string? sourceName, string host, int port, CancellationToken ct)
     {
         // Defaults for backward compatibility in tests or if options not bound
@@ -119,7 +119,7 @@ public sealed class SftpFileContentReader : IFileContentReader
         var privateKeyPem = await _secretResolver.ResolveSecretAsync(sftp.PrivateKeySecretRef, ct).ConfigureAwait(false);
         var privateKeyPass = await _secretResolver.ResolveSecretAsync(sftp.PrivateKeyPassphraseSecretRef, ct).ConfigureAwait(false);
 
-        return (username, password, privateKeyPem, privateKeyPass, sftp.HostKeyFingerprint, sftp.StrictHostKey);
+        return (username, password, privateKeyPem, privateKeyPass, sftp.AllHostKeyFingerprints(), sftp.StrictHostKey);
     }
 
     private static bool TryResolveEndpoint(FileReference file, out string host, out int port, out string path)

--- a/src/FileHorizon.Application/Infrastructure/Remote/SftpRemoteFileClient.cs
+++ b/src/FileHorizon.Application/Infrastructure/Remote/SftpRemoteFileClient.cs
@@ -20,7 +20,7 @@ public sealed class SftpRemoteFileClient : IRemoteFileClient
     private readonly string? _password;
     private readonly string? _privateKeyPem;
     private readonly string? _privateKeyPassphrase;
-    private readonly string? _hostKeyFingerprint;
+    private readonly IReadOnlyList<string>? _hostKeyFingerprints;
     private readonly bool _strictHostKey;
     private SftpClient? _client;
 
@@ -32,7 +32,7 @@ public sealed class SftpRemoteFileClient : IRemoteFileClient
         string? password,
         string? privateKeyPem,
         string? privateKeyPassphrase,
-        string? hostKeyFingerprint = null,
+        IReadOnlyList<string>? hostKeyFingerprints = null,
         bool strictHostKey = false)
     {
         _logger = logger;
@@ -42,7 +42,7 @@ public sealed class SftpRemoteFileClient : IRemoteFileClient
         _password = password;
         _privateKeyPem = privateKeyPem;
         _privateKeyPassphrase = privateKeyPassphrase;
-        _hostKeyFingerprint = hostKeyFingerprint;
+        _hostKeyFingerprints = hostKeyFingerprints;
         _strictHostKey = strictHostKey;
     }
 
@@ -90,7 +90,7 @@ public sealed class SftpRemoteFileClient : IRemoteFileClient
             client = new SftpClient(_host, _port, _username, _password ?? string.Empty);
         }
         client.HostKeyReceived += (_, e) =>
-            e.CanTrust = SshHostKeyValidator.Validate(_logger, _host, _port, _hostKeyFingerprint, _strictHostKey, e.HostKeyName, e.HostKey);
+            e.CanTrust = SshHostKeyValidator.Validate(_logger, _host, _port, _hostKeyFingerprints, _strictHostKey, e.HostKeyName, e.HostKey);
         return client;
     }
 

--- a/src/FileHorizon.Application/Infrastructure/Remote/SshHostKeyValidator.cs
+++ b/src/FileHorizon.Application/Infrastructure/Remote/SshHostKeyValidator.cs
@@ -4,7 +4,7 @@ using System.Security.Cryptography;
 namespace FileHorizon.Application.Infrastructure.Remote;
 
 /// <summary>
-/// Validates SSH server host keys against an operator-configured pinned fingerprint.
+/// Validates SSH server host keys against one or more operator-configured pinned fingerprints.
 /// Supported fingerprint formats: OpenSSH SHA256 ("SHA256:&lt;base64&gt;"), bare base64 SHA256,
 /// and legacy MD5 hex pairs separated by colons ("16:27:ac:...").
 /// </summary>
@@ -12,13 +12,16 @@ public static class SshHostKeyValidator
 {
     /// <summary>
     /// Decide whether the presented host key can be trusted.
-    /// When a fingerprint is configured it must match. When none is configured, the key is
-    /// accepted only if <paramref name="strictHostKey"/> is false (with a warning logged).
+    /// When any fingerprints are configured the presented key must match at least one of them.
+    /// When none are configured, the key is accepted only if <paramref name="strictHostKey"/> is
+    /// false (with a warning logged).
     /// </summary>
-    public static bool Validate(ILogger logger, string host, int port, string? expectedFingerprint, bool strictHostKey, string hostKeyName, byte[] hostKey)
+    public static bool Validate(ILogger logger, string host, int port, IReadOnlyList<string>? expectedFingerprints, bool strictHostKey, string hostKeyName, byte[] hostKey)
     {
         var presented = ToSha256Fingerprint(hostKey);
-        if (string.IsNullOrWhiteSpace(expectedFingerprint))
+        var expected = expectedFingerprints?.Where(f => !string.IsNullOrWhiteSpace(f)).ToArray() ?? [];
+
+        if (expected.Length == 0)
         {
             if (strictHostKey)
             {
@@ -29,13 +32,26 @@ public static class SshHostKeyValidator
             return true;
         }
 
-        if (FingerprintMatches(expectedFingerprint, hostKey))
+        if (AnyFingerprintMatches(expected, hostKey))
         {
-            logger.LogDebug("SSH host key for {Host}:{Port} matched configured fingerprint ({KeyType} {Fingerprint})", host, port, hostKeyName, presented);
+            logger.LogDebug("SSH host key for {Host}:{Port} matched a configured fingerprint ({KeyType} {Fingerprint})", host, port, hostKeyName, presented);
             return true;
         }
 
-        logger.LogError("Rejecting SSH host key for {Host}:{Port}: presented key {KeyType} {Fingerprint} does not match configured HostKeyFingerprint", host, port, hostKeyName, presented);
+        logger.LogError("Rejecting SSH host key for {Host}:{Port}: presented key {KeyType} {Fingerprint} does not match any of the {Count} configured host key fingerprint(s)", host, port, hostKeyName, presented, expected.Length);
+        return false;
+    }
+
+    /// <summary>
+    /// True when the host key matches at least one of the supplied fingerprints.
+    /// </summary>
+    public static bool AnyFingerprintMatches(IEnumerable<string> expectedFingerprints, byte[] hostKey)
+    {
+        foreach (var expected in expectedFingerprints)
+        {
+            if (string.IsNullOrWhiteSpace(expected)) continue;
+            if (FingerprintMatches(expected, hostKey)) return true;
+        }
         return false;
     }
 

--- a/src/FileHorizon.Application/Infrastructure/Remote/SshNetSftpClientAdapter.cs
+++ b/src/FileHorizon.Application/Infrastructure/Remote/SshNetSftpClientAdapter.cs
@@ -10,7 +10,7 @@ public sealed class SshNetSftpClientFactory(ILogger<SshNetSftpClientFactory> log
 {
     private readonly ILogger<SshNetSftpClientFactory> _logger = logger;
 
-    public FileHorizon.Application.Abstractions.ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase, string? hostKeyFingerprint = null, bool strictHostKey = false)
+    public FileHorizon.Application.Abstractions.ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase, IReadOnlyList<string>? hostKeyFingerprints = null, bool strictHostKey = false)
     {
         // Build ConnectionInfo
         ConnectionInfo connInfo;
@@ -31,7 +31,7 @@ public sealed class SshNetSftpClientFactory(ILogger<SshNetSftpClientFactory> log
 
         var client = new SftpClient(connInfo);
         client.HostKeyReceived += (_, e) =>
-            e.CanTrust = SshHostKeyValidator.Validate(_logger, host, port, hostKeyFingerprint, strictHostKey, e.HostKeyName, e.HostKey);
+            e.CanTrust = SshHostKeyValidator.Validate(_logger, host, port, hostKeyFingerprints, strictHostKey, e.HostKeyName, e.HostKey);
         return new SshNetSftpClientWrapper(_logger, client);
     }
 

--- a/test/FileHorizon.Application.Tests/HostKeyFingerprintConfigurationTests.cs
+++ b/test/FileHorizon.Application.Tests/HostKeyFingerprintConfigurationTests.cs
@@ -1,0 +1,163 @@
+using System.Security.Cryptography;
+using System.Text;
+using FileHorizon.Application.Configuration;
+using Xunit;
+
+namespace FileHorizon.Application.Tests;
+
+public class HostKeyFingerprintConfigurationTests
+{
+    private static string Fingerprint(string keyMaterial) =>
+        "SHA256:" + Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(keyMaterial))).TrimEnd('=');
+
+    private static readonly string Ed25519 = Fingerprint("ed25519-key");
+    private static readonly string Rsa = Fingerprint("rsa-key");
+
+    private static SftpSourceOptions ValidSource() => new()
+    {
+        Name = "src",
+        Host = "sftp.example.com",
+        Port = 22,
+        RemotePath = "/in",
+        Username = "user",
+        PasswordSecretRef = "env:PWD"
+    };
+
+    private static RemoteFileSourcesOptions Wrap(SftpSourceOptions sftp) => new() { Sftp = [sftp] };
+
+    // --- Combine -------------------------------------------------------------------------
+
+    [Fact]
+    public void AllHostKeyFingerprints_is_empty_when_nothing_configured()
+    {
+        Assert.Empty(new SftpSourceOptions().AllHostKeyFingerprints());
+    }
+
+    [Fact]
+    public void AllHostKeyFingerprints_returns_singular_value()
+    {
+        var options = new SftpSourceOptions { HostKeyFingerprint = Ed25519 };
+        Assert.Equal([Ed25519], options.AllHostKeyFingerprints());
+    }
+
+    [Fact]
+    public void AllHostKeyFingerprints_unions_singular_and_plural_with_singular_first()
+    {
+        var options = new SftpSourceOptions { HostKeyFingerprint = Ed25519, HostKeyFingerprints = [Rsa] };
+        Assert.Equal([Ed25519, Rsa], options.AllHostKeyFingerprints());
+    }
+
+    [Fact]
+    public void AllHostKeyFingerprints_trims_and_drops_blanks_and_duplicates()
+    {
+        var options = new SftpSourceOptions
+        {
+            HostKeyFingerprint = $"  {Ed25519}  ",
+            HostKeyFingerprints = ["", "   ", Ed25519, Rsa, Rsa]
+        };
+        Assert.Equal([Ed25519, Rsa], options.AllHostKeyFingerprints());
+    }
+
+    [Fact]
+    public void AllHostKeyFingerprints_works_when_only_plural_is_set()
+    {
+        var options = new SftpSourceOptions { HostKeyFingerprints = [Ed25519, Rsa] };
+        Assert.Equal([Ed25519, Rsa], options.AllHostKeyFingerprints());
+    }
+
+    // --- IsWellFormed --------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("SHA256:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU")]
+    [InlineData("sha256:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU")]
+    [InlineData("47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU")]
+    [InlineData("47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=")]
+    [InlineData("16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48")]
+    [InlineData("16:27:AC:A5:76:28:2D:36:63:1B:56:4D:EB:DF:A6:48")]
+    public void IsWellFormed_accepts_supported_formats(string fingerprint)
+    {
+        Assert.True(HostKeyFingerprintSet.IsWellFormed(fingerprint));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not-a-fingerprint")]
+    [InlineData("SHA256:tooshort")]
+    [InlineData("16:27:ac")]                                        // too few MD5 octets
+    [InlineData("zz:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48")] // non-hex octet
+    [InlineData("SHA256:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU,SHA256:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU")]
+    public void IsWellFormed_rejects_malformed_values(string fingerprint)
+    {
+        Assert.False(HostKeyFingerprintSet.IsWellFormed(fingerprint));
+    }
+
+    // --- Options validation --------------------------------------------------------------
+
+    private static Microsoft.Extensions.Options.ValidateOptionsResult Validate(SftpSourceOptions sftp) =>
+        new RemoteFileSourcesOptionsValidator().Validate(null, Wrap(sftp));
+
+    [Fact]
+    public void Strict_with_only_plural_fingerprints_is_valid()
+    {
+        var sftp = ValidSource();
+        sftp.StrictHostKey = true;
+        sftp.HostKeyFingerprints = [Ed25519, Rsa];
+
+        Assert.True(Validate(sftp).Succeeded);
+    }
+
+    [Fact]
+    public void Strict_without_any_fingerprint_fails()
+    {
+        var sftp = ValidSource();
+        sftp.StrictHostKey = true;
+
+        var result = Validate(sftp);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures, f => f.Contains("StrictHostKey is enabled but no HostKeyFingerprint"));
+    }
+
+    [Fact]
+    public void Strict_with_only_blank_plural_entries_fails()
+    {
+        var sftp = ValidSource();
+        sftp.StrictHostKey = true;
+        sftp.HostKeyFingerprints = ["", "   "];
+
+        Assert.True(Validate(sftp).Failed);
+    }
+
+    [Fact]
+    public void Malformed_fingerprint_fails_validation()
+    {
+        var sftp = ValidSource();
+        sftp.HostKeyFingerprints = [Ed25519, "obviously-not-a-fingerprint"];
+
+        var result = Validate(sftp);
+
+        Assert.True(result.Failed);
+        Assert.Contains(result.Failures, f => f.Contains("obviously-not-a-fingerprint") && f.Contains("not a recognised format"));
+    }
+
+    [Fact]
+    public void Comma_separated_list_in_singular_property_fails_validation()
+    {
+        // Operators may reasonably guess that a delimiter works; it must not silently break every connection.
+        var sftp = ValidSource();
+        sftp.HostKeyFingerprint = $"{Ed25519},{Rsa}";
+
+        Assert.True(Validate(sftp).Failed);
+    }
+
+    [Fact]
+    public void Well_formed_fingerprints_pass_validation()
+    {
+        var sftp = ValidSource();
+        sftp.HostKeyFingerprint = Ed25519;
+        sftp.HostKeyFingerprints = [Rsa, "16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48"];
+
+        Assert.True(Validate(sftp).Succeeded);
+    }
+}

--- a/test/FileHorizon.Application.Tests/SftpFileContentReaderTests.cs
+++ b/test/FileHorizon.Application.Tests/SftpFileContentReaderTests.cs
@@ -24,7 +24,7 @@ public sealed class SftpFileContentReaderTests
     {
         private readonly ISftpClient _client;
         public FakeFactory(ISftpClient client) { _client = client; }
-        public ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase, string? hostKeyFingerprint = null, bool strictHostKey = false) => _client;
+        public ISftpClient Create(string host, int port, string username, string? password, string? privateKeyPem, string? privateKeyPassphrase, IReadOnlyList<string>? hostKeyFingerprints = null, bool strictHostKey = false) => _client;
     }
 
     [Fact]

--- a/test/FileHorizon.Application.Tests/SshHostKeyValidatorTests.cs
+++ b/test/FileHorizon.Application.Tests/SshHostKeyValidatorTests.cs
@@ -8,9 +8,12 @@ namespace FileHorizon.Application.Tests;
 public sealed class SshHostKeyValidatorTests
 {
     private static readonly byte[] HostKey = Encoding.UTF8.GetBytes("fake-ssh-host-key-material");
+    private static readonly byte[] OtherHostKey = Encoding.UTF8.GetBytes("second-fake-ssh-host-key-material");
 
-    private static string Sha256Base64Unpadded() =>
-        Convert.ToBase64String(SHA256.HashData(HostKey)).TrimEnd('=');
+    private static string Sha256Base64Unpadded(byte[]? key = null) =>
+        Convert.ToBase64String(SHA256.HashData(key ?? HostKey)).TrimEnd('=');
+
+    private static string OpenSshFingerprint(byte[]? key = null) => $"SHA256:{Sha256Base64Unpadded(key)}";
 
     private static string Md5ColonHex()
     {
@@ -21,7 +24,7 @@ public sealed class SshHostKeyValidatorTests
     [Fact]
     public void Matches_openssh_sha256_format()
     {
-        Assert.True(SshHostKeyValidator.FingerprintMatches($"SHA256:{Sha256Base64Unpadded()}", HostKey));
+        Assert.True(SshHostKeyValidator.FingerprintMatches(OpenSshFingerprint(), HostKey));
     }
 
     [Fact]
@@ -46,22 +49,21 @@ public sealed class SshHostKeyValidatorTests
     [Fact]
     public void Rejects_wrong_fingerprint()
     {
-        var other = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes("different-key"))).TrimEnd('=');
-        Assert.False(SshHostKeyValidator.FingerprintMatches($"SHA256:{other}", HostKey));
+        Assert.False(SshHostKeyValidator.FingerprintMatches(OpenSshFingerprint(OtherHostKey), HostKey));
         Assert.False(SshHostKeyValidator.FingerprintMatches("16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48", HostKey));
     }
 
     [Fact]
     public void Validate_accepts_matching_fingerprint()
     {
-        var ok = SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, $"SHA256:{Sha256Base64Unpadded()}", strictHostKey: true, "ssh-ed25519", HostKey);
+        var ok = SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, [OpenSshFingerprint()], strictHostKey: true, "ssh-ed25519", HostKey);
         Assert.True(ok);
     }
 
     [Fact]
     public void Validate_rejects_mismatched_fingerprint()
     {
-        var ok = SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", strictHostKey: false, "ssh-ed25519", HostKey);
+        var ok = SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, ["SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"], strictHostKey: false, "ssh-ed25519", HostKey);
         Assert.False(ok);
     }
 
@@ -77,5 +79,50 @@ public sealed class SshHostKeyValidatorTests
     {
         var ok = SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, null, strictHostKey: false, "ssh-ed25519", HostKey);
         Assert.True(ok);
+    }
+
+    [Fact]
+    public void Validate_with_empty_list_behaves_as_unconfigured()
+    {
+        Assert.False(SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, [], strictHostKey: true, "ssh-ed25519", HostKey));
+        Assert.True(SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, [], strictHostKey: false, "ssh-ed25519", HostKey));
+    }
+
+    [Fact]
+    public void Validate_with_only_blank_entries_behaves_as_unconfigured()
+    {
+        // A list of blanks must not be treated as "pinned to nothing" and silently accept everything under strict.
+        Assert.False(SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, ["", "   "], strictHostKey: true, "ssh-ed25519", HostKey));
+    }
+
+    [Fact]
+    public void Validate_accepts_when_any_listed_fingerprint_matches()
+    {
+        string[] pinned = [OpenSshFingerprint(OtherHostKey), OpenSshFingerprint()];
+        Assert.True(SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, pinned, strictHostKey: true, "ssh-ed25519", HostKey));
+
+        // ...and the other key in the list is trusted too — the rotation / multi-algorithm case.
+        Assert.True(SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, pinned, strictHostKey: true, "ssh-rsa", OtherHostKey));
+    }
+
+    [Fact]
+    public void Validate_rejects_when_no_listed_fingerprint_matches()
+    {
+        string[] pinned = [OpenSshFingerprint(OtherHostKey), "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"];
+        Assert.False(SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, pinned, strictHostKey: true, "ssh-ed25519", HostKey));
+    }
+
+    [Fact]
+    public void Validate_accepts_mixed_fingerprint_formats_in_one_list()
+    {
+        string[] pinned = [OpenSshFingerprint(OtherHostKey), Md5ColonHex()];
+        Assert.True(SshHostKeyValidator.Validate(NullLogger.Instance, "host", 22, pinned, strictHostKey: true, "ssh-ed25519", HostKey));
+    }
+
+    [Fact]
+    public void AnyFingerprintMatches_skips_blank_entries()
+    {
+        Assert.True(SshHostKeyValidator.AnyFingerprintMatches(["", "  ", OpenSshFingerprint()], HostKey));
+        Assert.False(SshHostKeyValidator.AnyFingerprintMatches(["", "  "], HostKey));
     }
 }


### PR DESCRIPTION
Fixes #36

Lets an SFTP source pin more than one host key fingerprint. A presented host key is trusted when it matches **any** configured fingerprint.

## Why

`HostKeyFingerprint` was a single `string?`, and there was no delimiter workaround — a comma-separated value fell into the legacy-MD5 branch of `FingerprintMatches`, failed to match, and rejected the connection with no hint that the config shape was the problem.

That made two ordinary situations awkward:

- **Multiple host key algorithms.** A server offering both ed25519 and RSA may present either, depending on what SSH.NET negotiates. Pinning one means an algorithm change (server reconfig, library upgrade reordering preferences) breaks transfers.
- **Key rotation.** Required a hard cutover, with no window in which both the outgoing and incoming key are trusted.

## Changes

- `SftpSourceOptions.HostKeyFingerprints` — a list, in the same formats as the singular property.
- `HostKeyFingerprintSet` (new) — combines the singular and plural properties into one de-duplicated, trimmed list, and provides the format check below.
- `SshHostKeyValidator.Validate` now takes `IReadOnlyList<string>?` and accepts on any match; `AnyFingerprintMatches` added.
- Plumbing threaded through `ISftpClientFactory`, `SshNetSftpClientFactory`, `SftpRemoteFileClient`, `SftpPoller`, `SftpFileContentReader` and `FileProcessingOrchestrator`.
- Startup validation of fingerprint *format*, so a typo — or a guessed comma-separated list — fails fast with a clear message instead of surfacing later as a runtime rejection.
- `StrictHostKey`'s "at least one fingerprint" check now considers both properties.
- README: new **SFTP Host Key Verification** section covering formats, how to obtain a fingerprint, the multi-key rationale, and a `StrictHostKey` behaviour matrix.

## Compatibility

- **Configuration is fully backward compatible.** `HostKeyFingerprint` keeps working exactly as before. Setting both properties accepts the union. Supported formats (OpenSSH SHA256, bare base64, legacy MD5 hex) are unchanged, and may be mixed within a list.
- **One source-breaking API change:** the `string?` overload of `SshHostKeyValidator.Validate` is removed rather than kept alongside the list overload. Keeping both made a `null` argument ambiguous (CS0121) — a trap for callers, and it broke the existing tests immediately. All in-repo call sites are updated. `FingerprintMatches(string, byte[])` is unchanged.
- `ISftpClientFactory.Create` takes `IReadOnlyList<string>?` in place of `string?` — relevant to any out-of-tree implementer of the interface.

One deliberate call worth flagging: a delimited list in the singular property is now **rejected at startup** rather than ignored. It never worked, but it previously failed as a confusing connection rejection; failing loudly at startup seemed better than continuing to fail quietly. Easy to drop if you'd rather not add that strictness.

## Tests

`dotnet test` — 250 passed, 0 failed, 3 skipped.

New coverage: any-match acceptance across a list, rejection when nothing matches, mixed formats in one list, empty/blank-only lists treated as unconfigured (so a list of blanks can't silently satisfy `StrictHostKey`), the singular/plural union with de-duplication and trimming, format validation accept/reject cases, and the comma-separated-list config error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
