### PR TITLE
feat(idempotency): add --import-idempotency to move markers between stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,29 @@ Notes:
 - Seeding a file that is mid-upload is harmless: the completed file has a different size or mtime, hence a different key, and still transfers.
 - Marker keys have the form `fh:idemp:v2:{identityKey}|{size}|{mtime}`, e.g. `fh:idemp:v2:sftp://host:22/upload/a.zip|1234|2026-07-14T09:13:22.0000000+00:00`. Note the `+00:00` offset rather than `Z`; prefer this command over hand-writing markers, since a mismatched key is skipped with only a warning and the file transfers anyway.
 
+### Moving markers to another idempotency store
+
+Changing store — typically the file-backed store to Redis when a service moves onto Kubernetes — otherwise starts the new deployment with no history and re-downloads every file still present on the source. Copy the old deployment's `idempotency.jsonl` to somewhere the new deployment can read, then import it:
+
+```
+FileHorizon.Host.exe --import-idempotency /path/to/old/idempotency.jsonl [--dry-run]
+```
+
+This reads the file, writes every marker through `IIdempotencyStore` into whichever store the current configuration selects, and exits without starting the pipeline. Marker keys are store-agnostic — `FileIdentity` derives them from the source host, path, size and mtime, with nothing about the machine running FileHorizon — so the keys in the file are the keys the new deployment will look up.
+
+- `--dry-run` parses the file and reports what would happen without writing anything (and does not require a durable store).
+- Exit codes: `0` success, `1` the import failed part-way, `2` bad arguments or unusable configuration.
+- Re-running is safe: markers already present are counted as `already known`, not duplicated.
+
+Notes:
+
+- **Keep the source configuration identical.** The key embeds the SFTP/FTP host as configured, its port and the remote path. Swapping a hostname for its FQDN or IP, or changing `RemotePath`, produces different keys and the imported markers will not match.
+- Retention is per-marker: an entry with no expiry stays permanent, one with an expiry is written with the time it had left, and one that has already expired is dropped rather than resurrected.
+- The report ends in `FAILED` and exit `1` if a marker was neither written nor present afterwards. The stores deliberately fail open, so a Redis outage returns "not marked" rather than throwing; the import verifies each such marker instead of reporting a lost migration as a clean one.
+- Stop the old service before copying its file, so the copy has no torn final line — though a torn line is skipped and counted rather than failing the import.
+- Importing into Redis inherits Redis's durability, which is weaker than a file on disk unless configured: a pod with no persistent volume loses every marker on reschedule, and `maxmemory-policy allkeys-lru` can evict markers that have no TTL (the default `Idempotency:TtlSeconds=0`). Use a persistent volume with AOF enabled and `noeviction`.
+- Alternatively, if the source has been drained, `--seed-idempotency` achieves the same outcome without a file: markers for files no longer on the source can never match again, so only the files still present matter. It also suppresses files the old deployment had not yet transferred, so only do that during a quiet window.
+
 ### Destinations: Adding Azure Service Bus
 
 Destinations now support a Service Bus variant alongside `Local` and `Sftp`. A Service Bus destination allows routing rules to direct a file's full content into a queue or topic after it has been read. The orchestrator identifies the destination kind and invokes the `IFileContentPublisher` abstraction instead of a file sink.

--- a/src/FileHorizon.Application/Infrastructure/Idempotency/FileBackedIdempotencyStore.cs
+++ b/src/FileHorizon.Application/Infrastructure/Idempotency/FileBackedIdempotencyStore.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using FileHorizon.Application.Abstractions;
 using Microsoft.Extensions.Logging;
 
@@ -21,18 +20,25 @@ public sealed class FileBackedIdempotencyStore : IIdempotencyStore, IDisposable
     private readonly StreamWriter _writer;
     private readonly ILogger<FileBackedIdempotencyStore> _logger;
 
+    /// <summary>
+    /// Absolute path of the backing file. Exposed so a caller that reads idempotency files itself - the
+    /// import command - can tell whether it has been pointed at this store's own file.
+    /// </summary>
+    public string FilePath { get; }
+
     public FileBackedIdempotencyStore(string filePath, ILogger<FileBackedIdempotencyStore> logger)
     {
         _logger = logger;
-        var directory = Path.GetDirectoryName(Path.GetFullPath(filePath));
+        FilePath = Path.GetFullPath(filePath);
+        var directory = Path.GetDirectoryName(FilePath);
         if (!string.IsNullOrEmpty(directory))
         {
             Directory.CreateDirectory(directory);
         }
 
-        LoadExistingEntries(filePath);
+        LoadExistingEntries(FilePath);
 
-        var stream = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+        var stream = new FileStream(FilePath, FileMode.Append, FileAccess.Write, FileShare.Read);
         _writer = new StreamWriter(stream);
     }
 
@@ -52,7 +58,7 @@ public sealed class FileBackedIdempotencyStore : IIdempotencyStore, IDisposable
                 return false;
             }
             _entries[key] = expiry;
-            await _writer.WriteLineAsync(JsonSerializer.Serialize(new Entry(key, expiry))).ConfigureAwait(false);
+            await _writer.WriteLineAsync(JsonSerializer.Serialize(new IdempotencyFileEntry(key, expiry))).ConfigureAwait(false);
             await _writer.FlushAsync(ct).ConfigureAwait(false);
             return true;
         }
@@ -81,30 +87,14 @@ public sealed class FileBackedIdempotencyStore : IIdempotencyStore, IDisposable
             return;
         }
 
-        var loaded = 0;
-        var skipped = 0;
-        foreach (var line in File.ReadLines(filePath))
+        var contents = IdempotencyFileReader.Read(filePath);
+        foreach (var entry in contents.Entries)
         {
-            if (string.IsNullOrWhiteSpace(line)) continue;
-            try
-            {
-                var entry = JsonSerializer.Deserialize<Entry>(line);
-                if (entry?.Key is null)
-                {
-                    skipped++;
-                    continue;
-                }
-                // Last write wins for a key that appears multiple times.
-                _entries[entry.Key] = entry.ExpiresAtUtc;
-                loaded++;
-            }
-            catch (JsonException)
-            {
-                // A torn final line after a crash is expected; skip it.
-                skipped++;
-            }
+            _entries[entry.Key] = entry.ExpiresAtUtc;
         }
 
+        var loaded = contents.Entries.Count;
+        var skipped = contents.SkippedLines;
         if (skipped > 0)
         {
             _logger.LogWarning("Idempotency file {Path}: skipped {Skipped} unreadable line(s) while loading {Loaded} marker(s)", filePath, skipped, loaded);
@@ -114,8 +104,4 @@ public sealed class FileBackedIdempotencyStore : IIdempotencyStore, IDisposable
             _logger.LogInformation("Idempotency file {Path}: loaded {Loaded} marker(s)", filePath, loaded);
         }
     }
-
-    private sealed record Entry(
-        [property: JsonPropertyName("k")] string Key,
-        [property: JsonPropertyName("e")] DateTimeOffset? ExpiresAtUtc);
 }

--- a/src/FileHorizon.Application/Infrastructure/Idempotency/IdempotencyFileReader.cs
+++ b/src/FileHorizon.Application/Infrastructure/Idempotency/IdempotencyFileReader.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FileHorizon.Application.Infrastructure.Idempotency;
+
+/// <summary>
+/// One line of the JSONL file written by <see cref="FileBackedIdempotencyStore"/>: a marker key and the
+/// instant it expires, null meaning it never does.
+/// </summary>
+internal sealed record IdempotencyFileEntry(
+    [property: JsonPropertyName("k")] string Key,
+    [property: JsonPropertyName("e")] DateTimeOffset? ExpiresAtUtc);
+
+/// <summary>
+/// What one pass over an idempotency file produced.
+/// </summary>
+/// <param name="Entries">Distinct keys in the order first seen, each carrying its last recorded expiry.</param>
+/// <param name="Lines">Non-blank lines read.</param>
+/// <param name="SkippedLines">Lines that could not be read as an entry.</param>
+internal sealed record IdempotencyFileContents(
+    IReadOnlyList<IdempotencyFileEntry> Entries,
+    int Lines,
+    int SkippedLines);
+
+/// <summary>
+/// Reads the JSONL idempotency file. Shared by <see cref="FileBackedIdempotencyStore"/>'s load path and
+/// <see cref="IdempotencyImporter"/>, so a file cannot mean one thing to the store that wrote it and
+/// something else to the import that moves those markers into another store.
+/// </summary>
+internal static class IdempotencyFileReader
+{
+    /// <summary>
+    /// Reads every entry from <paramref name="filePath"/>, which must exist. Unreadable lines are counted
+    /// rather than thrown: a torn final line is the normal result of a crash mid-append, and discarding one
+    /// marker only costs a single re-transfer, while refusing the whole file would cost the entire history.
+    /// </summary>
+    public static IdempotencyFileContents Read(string filePath)
+    {
+        var expiryByKey = new Dictionary<string, DateTimeOffset?>(StringComparer.Ordinal);
+        var order = new List<string>();
+        var lines = 0;
+        var skipped = 0;
+
+        foreach (var line in File.ReadLines(filePath))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            lines++;
+
+            IdempotencyFileEntry? entry;
+            try
+            {
+                entry = JsonSerializer.Deserialize<IdempotencyFileEntry>(line);
+            }
+            catch (JsonException)
+            {
+                skipped++;
+                continue;
+            }
+            if (entry?.Key is null)
+            {
+                skipped++;
+                continue;
+            }
+
+            // Last write wins for a key that appears more than once; the key keeps the position where it
+            // first appeared so callers report keys in file order.
+            if (!expiryByKey.ContainsKey(entry.Key)) order.Add(entry.Key);
+            expiryByKey[entry.Key] = entry.ExpiresAtUtc;
+        }
+
+        var entries = order.Select(k => new IdempotencyFileEntry(k, expiryByKey[k])).ToList();
+        return new IdempotencyFileContents(entries, lines, skipped);
+    }
+}

--- a/src/FileHorizon.Application/Infrastructure/Idempotency/IdempotencyImporter.cs
+++ b/src/FileHorizon.Application/Infrastructure/Idempotency/IdempotencyImporter.cs
@@ -1,0 +1,162 @@
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Common;
+using Microsoft.Extensions.Logging;
+
+namespace FileHorizon.Application.Infrastructure.Idempotency;
+
+/// <summary>
+/// Parameters for importing markers from a JSONL idempotency file into the configured store.
+/// </summary>
+/// <param name="FilePath">Path to a file written by the file-backed store.</param>
+/// <param name="DryRun">When true, the file is parsed and reported on but no markers are written.</param>
+public sealed record IdempotencyImportRequest(string FilePath, bool DryRun = false);
+
+/// <summary>
+/// Outcome of an import run.
+/// </summary>
+/// <param name="FilePath">Absolute path of the file that was read.</param>
+/// <param name="Lines">Non-blank lines in the file.</param>
+/// <param name="Keys">Distinct marker keys those lines describe.</param>
+/// <param name="Imported">Markers this run created in the target store (always 0 for a dry run).</param>
+/// <param name="AlreadyPresent">Markers the target store already held.</param>
+/// <param name="Expired">Markers whose recorded expiry had already passed, so they were dropped.</param>
+/// <param name="Unreadable">Lines that could not be parsed and were skipped.</param>
+/// <param name="Failed">Markers the target store neither created nor holds - a store that swallowed the write.</param>
+/// <param name="SampleKeys">First few keys from the file, for eyeballing before committing to a large run.</param>
+public sealed record IdempotencyImportResult(
+    string FilePath,
+    int Lines,
+    int Keys,
+    int Imported,
+    int AlreadyPresent,
+    int Expired,
+    int Unreadable,
+    int Failed,
+    IReadOnlyList<string> SampleKeys);
+
+/// <summary>
+/// Copies markers from a file-backed idempotency file into whichever store is configured, so a deployment
+/// can change stores - typically file to Redis when a service moves into Kubernetes - without losing the
+/// record of what has already been transferred.
+/// </summary>
+/// <remarks>
+/// Marker keys are store-agnostic: <see cref="FileIdentity.BuildIdempotencyKey"/> derives them from the
+/// source host, path, size and mtime alone, with nothing about the machine running FileHorizon, so the keys
+/// in the file are the keys the pipeline will look up after the move. Only retention is per-store, and each
+/// marker keeps the lifetime it had left - no expiry stays permanent, a future expiry is written with the
+/// time remaining, and one that has already passed is dropped rather than resurrected.
+/// </remarks>
+public sealed class IdempotencyImporter
+{
+    private const int SampleKeyCount = 5;
+
+    private readonly ILogger<IdempotencyImporter> _logger;
+
+    public IdempotencyImporter(ILogger<IdempotencyImporter> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<Result<IdempotencyImportResult>> ImportAsync(
+        IdempotencyImportRequest request,
+        IIdempotencyStore store,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(store);
+
+        if (string.IsNullOrWhiteSpace(request.FilePath))
+        {
+            return Result<IdempotencyImportResult>.Failure(
+                Error.Validation.Invalid("An idempotency file path is required."));
+        }
+
+        var path = Path.GetFullPath(request.FilePath);
+        if (!File.Exists(path))
+        {
+            return Result<IdempotencyImportResult>.Failure(Error.File.NotFound(path));
+        }
+
+        IdempotencyFileContents contents;
+        try
+        {
+            contents = IdempotencyFileReader.Read(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return Result<IdempotencyImportResult>.Failure(
+                Error.Unspecified("Idempotency.ImportFailed", $"Could not read '{path}': {ex.Message}"));
+        }
+
+        var samples = contents.Entries.Take(SampleKeyCount).Select(e => e.Key).ToList();
+        var now = DateTimeOffset.UtcNow;
+        var imported = 0;
+        var alreadyPresent = 0;
+        var expired = 0;
+        var failed = 0;
+
+        try
+        {
+            foreach (var entry in contents.Entries)
+            {
+                if (ct.IsCancellationRequested) break;
+
+                TimeSpan? ttl = null;
+                if (entry.ExpiresAtUtc is { } expiresAt)
+                {
+                    var remaining = expiresAt - now;
+                    if (remaining <= TimeSpan.Zero)
+                    {
+                        expired++;
+                        continue;
+                    }
+                    ttl = remaining;
+                }
+
+                if (request.DryRun) continue;
+
+                if (await store.TryMarkProcessedAsync(entry.Key, ttl, ct).ConfigureAwait(false))
+                {
+                    imported++;
+                    continue;
+                }
+
+                // The stores fail open: a Redis outage makes TryMarkProcessedAsync return false, which is
+                // indistinguishable from "already there" - and for a migration that difference is the whole
+                // point, since a silent run of nothing-to-do would read as a successful import. Confirming
+                // the marker is really present turns a swallowed write into a reported failure.
+                if (await store.IsProcessedAsync(entry.Key, ct).ConfigureAwait(false))
+                {
+                    alreadyPresent++;
+                }
+                else
+                {
+                    failed++;
+                }
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Markers written before the failure are durable and correct, and re-importing them is a no-op,
+            // so report progress with the error and let the operator simply repeat the run.
+            _logger.LogError(ex, "Idempotency import from {Path} failed after importing {Imported} marker(s)", path, imported);
+            return Result<IdempotencyImportResult>.Failure(
+                Error.Unspecified("Idempotency.ImportFailed", $"Import from '{path}' failed after {imported} marker(s): {ex.Message}"));
+        }
+
+        _logger.LogInformation(
+            "Idempotency import from {Path} (dryRun={DryRun}): lines={Lines}, keys={Keys}, imported={Imported}, alreadyPresent={AlreadyPresent}, expired={Expired}, unreadable={Unreadable}, failed={Failed}",
+            path, request.DryRun, contents.Lines, contents.Entries.Count, imported, alreadyPresent, expired, contents.SkippedLines, failed);
+
+        return Result<IdempotencyImportResult>.Success(new IdempotencyImportResult(
+            path,
+            contents.Lines,
+            contents.Entries.Count,
+            imported,
+            alreadyPresent,
+            expired,
+            contents.SkippedLines,
+            failed,
+            samples));
+    }
+}

--- a/src/FileHorizon.Application/ServiceCollectionExtensions.cs
+++ b/src/FileHorizon.Application/ServiceCollectionExtensions.cs
@@ -131,8 +131,12 @@ public static class ServiceCollectionExtensions
         services.AddOptions<Configuration.ContentDetectionOptions>();
 
         // Records why the selection below fell back, so a caller that requires a durable store (the
-        // seeding command) can report the real cause instead of only "nothing durable is configured".
+        // seeding and import commands) can report the real cause instead of only "nothing durable is configured".
         services.AddSingleton<Infrastructure.Idempotency.IdempotencyStoreDiagnostics>();
+
+        // Used only by the one-off import command, registered here so it writes through the same store
+        // selection the pipeline gets.
+        services.AddSingleton<Infrastructure.Idempotency.IdempotencyImporter>();
 
         // Idempotency store selection: Redis (if enabled) -> file-backed (if DataDirectory set) -> in-memory.
         services.AddSingleton<Abstractions.IIdempotencyStore>(sp =>

--- a/src/FileHorizon.Host/Commands/CommandLineArgs.cs
+++ b/src/FileHorizon.Host/Commands/CommandLineArgs.cs
@@ -1,0 +1,24 @@
+namespace FileHorizon.Host.Commands;
+
+/// <summary>
+/// Minimal argument reading for the one-off maintenance commands. These flags deliberately bypass the
+/// command-line configuration provider (see Program.cs), so they are parsed by hand.
+/// </summary>
+internal static class CommandLineArgs
+{
+    public static bool HasFlag(string[] args, string name)
+        => args.Any(a => string.Equals(a, name, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Value following <paramref name="name"/>, or null when the flag is absent or last.</summary>
+    public static string? GetOption(string[] args, string name)
+    {
+        for (var i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase))
+            {
+                return args[i + 1];
+            }
+        }
+        return null;
+    }
+}

--- a/src/FileHorizon.Host/Commands/IdempotencyStoreRequirement.cs
+++ b/src/FileHorizon.Host/Commands/IdempotencyStoreRequirement.cs
@@ -1,0 +1,44 @@
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Infrastructure.Idempotency;
+
+namespace FileHorizon.Host.Commands;
+
+/// <summary>
+/// Shared reporting for the maintenance commands that write idempotency markers and therefore need a
+/// store that outlives the process.
+/// </summary>
+internal static class IdempotencyStoreRequirement
+{
+    /// <summary>
+    /// Explains why a command that requires durability will not run. The store registration lands on the
+    /// in-memory store for two very different reasons - nothing durable configured, or something durable
+    /// that would not open - and only the first is a configuration problem, so pointing at config either way
+    /// would send an operator hunting through appsettings when the real fix is to stop the running service.
+    /// </summary>
+    /// <param name="services">Built provider, for the recorded fallback cause.</param>
+    /// <param name="consequence">What the caller was about to write, and that it was not written.</param>
+    public static string DescribeUnusable(IServiceProvider services, string consequence)
+    {
+        var fallback = services.GetRequiredService<IdempotencyStoreDiagnostics>().Fallback;
+        if (fallback is null)
+        {
+            return $"No durable idempotency store is configured. {consequence} " +
+                   "Set Idempotency:DataDirectory (or enable Redis) and try again.";
+        }
+
+        var message = $"Configuration selects {fallback.Store}, but it could not be opened: {fallback.Reason} {consequence}";
+        return fallback.Hint is null ? message : $"{message} {fallback.Hint}";
+    }
+
+    /// <summary>
+    /// Names the store markers are going into. Which store took effect is the question an operator moving
+    /// between stores actually has, and the selection is silent about it outside the startup log.
+    /// </summary>
+    public static string Describe(IIdempotencyStore store) => store switch
+    {
+        FileBackedIdempotencyStore file => $"the file-backed store at {file.FilePath}",
+        RedisIdempotencyStore => "the Redis store",
+        InMemoryIdempotencyStore => "the in-memory store (nothing survives this process)",
+        _ => store.GetType().Name
+    };
+}

--- a/src/FileHorizon.Host/Commands/ImportIdempotencyCommand.cs
+++ b/src/FileHorizon.Host/Commands/ImportIdempotencyCommand.cs
@@ -1,0 +1,150 @@
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Configuration;
+using FileHorizon.Application.Infrastructure.Idempotency;
+using Microsoft.Extensions.Options;
+
+namespace FileHorizon.Host.Commands;
+
+/// <summary>
+/// One-off maintenance command: copies markers from a file-backed idempotency file into the configured
+/// store, so a deployment can move between stores - a service moving onto Kubernetes with Redis being the
+/// motivating case - without re-transferring everything the old deployment had already fetched.
+/// Runs inside the normal host so it writes through the same store selection as the pipeline, then exits
+/// without starting any background service.
+/// </summary>
+public static class ImportIdempotencyCommand
+{
+    public const string FlagName = "--import-idempotency";
+
+    public static bool IsRequested(string[] args) => CommandLineArgs.HasFlag(args, FlagName);
+
+    public static async Task<int> RunAsync(IServiceProvider services, string[] args, CancellationToken ct)
+    {
+        var filePath = CommandLineArgs.GetOption(args, FlagName);
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            Console.Error.WriteLine($"Usage: {FlagName} <path to idempotency.jsonl> [--dry-run]");
+            return 2;
+        }
+
+        // Resolved here rather than left to the importer so a path that does not exist is reported as the
+        // bad argument it is, alongside the usage error above, instead of as a failed run.
+        if (!TryResolvePath(filePath!, out var path, out var pathError))
+        {
+            Console.Error.WriteLine(pathError);
+            return 2;
+        }
+
+        var dryRun = CommandLineArgs.HasFlag(args, "--dry-run");
+        var store = services.GetRequiredService<IIdempotencyStore>();
+
+        if (!dryRun && store is InMemoryIdempotencyStore)
+        {
+            Console.Error.WriteLine(IdempotencyStoreRequirement.DescribeUnusable(
+                services,
+                "Imported markers would be discarded when this process exits, so nothing was written."));
+            return 2;
+        }
+
+        if (IsOwnFile(store, path!, out var ownFileError))
+        {
+            Console.Error.WriteLine(ownFileError);
+            return 2;
+        }
+
+        var idempotency = services.GetRequiredService<IOptions<IdempotencyOptions>>().Value;
+        if (!idempotency.Enabled)
+        {
+            Console.Error.WriteLine(
+                "Warning: Idempotency:Enabled is false, so the pipeline will not consult these markers until it is enabled.");
+        }
+
+        var importer = services.GetRequiredService<IdempotencyImporter>();
+        var result = await importer.ImportAsync(new IdempotencyImportRequest(path!, dryRun), store, ct).ConfigureAwait(false);
+        if (result.IsFailure)
+        {
+            Console.Error.WriteLine($"Import failed: {result.Error}");
+            return 1;
+        }
+
+        Report(result.Value!, store, dryRun);
+
+        // A swallowed write leaves the target store short of markers, which shows up later as an unwanted
+        // re-transfer rather than as an error, so it must not exit 0.
+        return result.Value!.Failed > 0 ? 1 : 0;
+    }
+
+    private static bool TryResolvePath(string filePath, out string? path, out string? error)
+    {
+        path = null;
+        error = null;
+        try
+        {
+            path = Path.GetFullPath(filePath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            error = $"'{filePath}' is not a usable path: {ex.Message}";
+            return false;
+        }
+
+        if (File.Exists(path)) return true;
+        error = $"No idempotency file at {path}.";
+        return false;
+    }
+
+    /// <summary>
+    /// Catches the file-backed store being handed its own file. That import reports every marker as already
+    /// present, since the store loaded them at construction, which reads as "nothing to do" when the operator
+    /// meant to import the file they copied off the old deployment.
+    /// </summary>
+    private static bool IsOwnFile(IIdempotencyStore store, string path, out string? error)
+    {
+        error = null;
+        if (store is not FileBackedIdempotencyStore fileStore) return false;
+
+        // Windows paths differ only in case; elsewhere they do not.
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        if (!string.Equals(fileStore.FilePath, path, comparison)) return false;
+
+        error = $"{path} is the configured store's own file (Idempotency:DataDirectory), whose markers are " +
+                "already loaded. Point --import-idempotency at the file copied from the deployment you are " +
+                "migrating from, or configure the store you are importing into.";
+        return true;
+    }
+
+    private static void Report(IdempotencyImportResult import, IIdempotencyStore store, bool dryRun)
+    {
+        Console.WriteLine(dryRun
+            ? $"Dry run for {import.FilePath} - nothing was written."
+            : $"Imported {import.FilePath} into {IdempotencyStoreRequirement.Describe(store)}.");
+        Console.WriteLine($"  lines read:    {import.Lines}");
+        Console.WriteLine($"  unique keys:   {import.Keys}");
+        if (!dryRun)
+        {
+            Console.WriteLine($"  imported:      {import.Imported}");
+            Console.WriteLine($"  already known: {import.AlreadyPresent}");
+        }
+        if (import.Expired > 0)
+        {
+            Console.WriteLine($"  expired:       {import.Expired} (dropped)");
+        }
+        if (import.Unreadable > 0)
+        {
+            Console.WriteLine($"  unreadable:    {import.Unreadable} line(s) skipped");
+        }
+        if (import.Failed > 0)
+        {
+            Console.Error.WriteLine(
+                $"  FAILED:        {import.Failed} marker(s) were neither written nor present afterwards. " +
+                "The store swallowed the write - check its connectivity and repeat the import.");
+        }
+
+        if (import.SampleKeys.Count == 0) return;
+        Console.WriteLine($"  sample keys ({import.SampleKeys.Count} of {import.Keys}):");
+        foreach (var key in import.SampleKeys)
+        {
+            Console.WriteLine($"    {key}");
+        }
+    }
+}

--- a/src/FileHorizon.Host/Commands/SeedIdempotencyCommand.cs
+++ b/src/FileHorizon.Host/Commands/SeedIdempotencyCommand.cs
@@ -16,19 +16,19 @@ public static class SeedIdempotencyCommand
 {
     public const string FlagName = "--seed-idempotency";
 
-    public static bool IsRequested(string[] args) => HasFlag(args, FlagName);
+    public static bool IsRequested(string[] args) => CommandLineArgs.HasFlag(args, FlagName);
 
     public static async Task<int> RunAsync(IServiceProvider services, string[] args, CancellationToken ct)
     {
-        var sourceName = GetOption(args, "--source");
+        var sourceName = CommandLineArgs.GetOption(args, "--source");
         if (string.IsNullOrWhiteSpace(sourceName))
         {
             Console.Error.WriteLine($"Usage: {FlagName} --source <name> [--pattern <glob>] [--dry-run]");
             return 2;
         }
 
-        var dryRun = HasFlag(args, "--dry-run");
-        var patternOverride = GetOption(args, "--pattern");
+        var dryRun = CommandLineArgs.HasFlag(args, "--dry-run");
+        var patternOverride = CommandLineArgs.GetOption(args, "--pattern");
 
         var remoteSources = services.GetRequiredService<IOptions<RemoteFileSourcesOptions>>().Value;
         var poller = ResolvePoller(services, remoteSources, sourceName, out var resolveError);
@@ -41,7 +41,9 @@ public static class SeedIdempotencyCommand
         var store = services.GetRequiredService<IIdempotencyStore>();
         if (!dryRun && store is InMemoryIdempotencyStore)
         {
-            Console.Error.WriteLine(DescribeUnusableStore(services));
+            Console.Error.WriteLine(IdempotencyStoreRequirement.DescribeUnusable(
+                services,
+                "Seeded markers would be discarded when this process exits, so nothing was written."));
             return 2;
         }
 
@@ -64,27 +66,6 @@ public static class SeedIdempotencyCommand
 
         Report(result.Value!, dryRun);
         return 0;
-    }
-
-    /// <summary>
-    /// Explains why seeding will not run. The store registration lands on the in-memory store for two
-    /// very different reasons - nothing durable configured, or something durable that would not open -
-    /// and only the first is a configuration problem, so pointing at config either way would send an
-    /// operator hunting through appsettings when the real fix is to stop the running service.
-    /// </summary>
-    private static string DescribeUnusableStore(IServiceProvider services)
-    {
-        const string consequence = "Seeded markers would be discarded when this process exits, so nothing was written.";
-
-        var fallback = services.GetRequiredService<IdempotencyStoreDiagnostics>().Fallback;
-        if (fallback is null)
-        {
-            return $"No durable idempotency store is configured. {consequence} " +
-                   "Set Idempotency:DataDirectory (or enable Redis) and try again.";
-        }
-
-        var message = $"Configuration selects {fallback.Store}, but it could not be opened: {fallback.Reason} {consequence}";
-        return fallback.Hint is null ? message : $"{message} {fallback.Hint}";
     }
 
     private static void Report(IdempotencySeedResult seed, bool dryRun)
@@ -146,20 +127,5 @@ public static class SeedIdempotencyCommand
             error = $"Cannot seed '{sourceName}': {ex.Message}. Set {flag}=true and try again.";
             return null;
         }
-    }
-
-    private static bool HasFlag(string[] args, string name)
-        => args.Any(a => string.Equals(a, name, StringComparison.OrdinalIgnoreCase));
-
-    private static string? GetOption(string[] args, string name)
-    {
-        for (var i = 0; i < args.Length - 1; i++)
-        {
-            if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase))
-            {
-                return args[i + 1];
-            }
-        }
-        return null;
     }
 }

--- a/src/FileHorizon.Host/Program.cs
+++ b/src/FileHorizon.Host/Program.cs
@@ -10,10 +10,12 @@ using OpenTelemetry.Trace;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Exporter.Prometheus;
 
-// Seeding flags are not configuration keys; keep them away from the command-line config provider,
+// Maintenance flags are not configuration keys; keep them away from the command-line config provider,
 // which rejects bare switches. Configuration still comes from appsettings and the environment.
 var seedRequested = SeedIdempotencyCommand.IsRequested(args);
-var builder = WebApplication.CreateBuilder(seedRequested ? [] : args);
+var importRequested = ImportIdempotencyCommand.IsRequested(args);
+var maintenanceRequested = seedRequested || importRequested;
+var builder = WebApplication.CreateBuilder(maintenanceRequested ? [] : args);
 
 builder.Services.AddApplicationServices();
 builder.Services.Configure<PollingOptions>(builder.Configuration.GetSection(PollingOptions.SectionName));
@@ -121,23 +123,38 @@ builder.Services.AddOpenTelemetry()
 
 var app = builder.Build();
 
-if (seedRequested)
+if (maintenanceRequested)
 {
-    // Maintenance path: seed idempotency markers and exit without starting any background service.
-    int seedExitCode;
+    // Maintenance path: write idempotency markers and exit without starting any background service.
+    int exitCode;
     try
     {
-        seedExitCode = await SeedIdempotencyCommand.RunAsync(app.Services, args, CancellationToken.None);
+        if (seedRequested && importRequested)
+        {
+            // Both write markers for the same source of truth; running them together would make the
+            // reported counts meaningless, and the operator wants one or the other.
+            Console.Error.WriteLine(
+                $"{SeedIdempotencyCommand.FlagName} and {ImportIdempotencyCommand.FlagName} cannot be combined; run one at a time.");
+            exitCode = 2;
+        }
+        else if (seedRequested)
+        {
+            exitCode = await SeedIdempotencyCommand.RunAsync(app.Services, args, CancellationToken.None);
+        }
+        else
+        {
+            exitCode = await ImportIdempotencyCommand.RunAsync(app.Services, args, CancellationToken.None);
+        }
     }
     catch (OptionsValidationException ex)
     {
         // Options bound by the command are validated on first resolution. A one-off command should
         // report unusable configuration as the documented exit 2, not as an unhandled crash.
         Console.Error.WriteLine($"Configuration is invalid: {string.Join("; ", ex.Failures)}");
-        seedExitCode = 2;
+        exitCode = 2;
     }
     await app.DisposeAsync();
-    return seedExitCode;
+    return exitCode;
 }
 
 app.MapHealthChecks("/health");

--- a/test/FileHorizon.Application.Tests/IdempotencyImportTests.cs
+++ b/test/FileHorizon.Application.Tests/IdempotencyImportTests.cs
@@ -1,0 +1,301 @@
+using FileHorizon.Application.Abstractions;
+using FileHorizon.Application.Infrastructure.Idempotency;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace FileHorizon.Application.Tests;
+
+public class IdempotencyImportTests
+{
+    // A key in the documented shape, so the tests fail if importing ever mangles a real marker.
+    private const string RealKey = "fh:idemp:v2:sftp://sftp.example.com:22/upload/a.zip|1234|2026-07-14T09:13:22.0000000+00:00";
+
+    private static string NewFilePath()
+        => Path.Combine(Path.GetTempPath(), "fh-idemp-import-tests", Guid.NewGuid().ToString("N"), "idempotency.jsonl");
+
+    private static IdempotencyImporter CreateImporter()
+        => new(NullLogger<IdempotencyImporter>.Instance);
+
+    private static void Cleanup(string path)
+    {
+        try { Directory.Delete(Path.GetDirectoryName(path)!, true); } catch { }
+    }
+
+    private static void WriteLines(string path, params string[] lines)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllLines(path, lines);
+    }
+
+    private static string Line(string key, DateTimeOffset? expiry = null)
+        => expiry is null
+            ? $"{{\"k\":\"{key}\",\"e\":null}}"
+            : $"{{\"k\":\"{key}\",\"e\":\"{expiry:O}\"}}";
+
+    [Fact]
+    public async Task ImportAsync_MovesMarkersWrittenByTheFileStoreIntoAnotherStore()
+    {
+        // The point of importing is that a marker written on the old deployment suppresses the same file on
+        // the new one, so the key must survive the move byte for byte.
+        var path = NewFilePath();
+        try
+        {
+            using (var fileStore = new FileBackedIdempotencyStore(path, NullLogger<FileBackedIdempotencyStore>.Instance))
+            {
+                Assert.True(await fileStore.TryMarkProcessedAsync(RealKey, null, CancellationToken.None));
+            }
+
+            var target = new InMemoryIdempotencyStore();
+            var result = await CreateImporter().ImportAsync(new IdempotencyImportRequest(path), target, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(1, result.Value!.Keys);
+            Assert.Equal(1, result.Value.Imported);
+            Assert.Equal(0, result.Value.AlreadyPresent);
+            Assert.Equal(0, result.Value.Failed);
+            Assert.True(await target.IsProcessedAsync(RealKey, CancellationToken.None));
+            Assert.Equal(RealKey, Assert.Single(result.Value.SampleKeys));
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ImportAsync_DryRun_WritesNothing()
+    {
+        var path = NewFilePath();
+        try
+        {
+            WriteLines(path, Line(RealKey));
+            var target = new InMemoryIdempotencyStore();
+
+            var result = await CreateImporter().ImportAsync(
+                new IdempotencyImportRequest(path, DryRun: true), target, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(1, result.Value!.Keys);
+            Assert.Equal(0, result.Value.Imported);
+            Assert.False(await target.IsProcessedAsync(RealKey, CancellationToken.None));
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ImportAsync_PermanentMarker_IsWrittenWithoutTtl()
+    {
+        var path = NewFilePath();
+        try
+        {
+            WriteLines(path, Line("k1"));
+            var target = new RecordingStore();
+
+            var result = await CreateImporter().ImportAsync(new IdempotencyImportRequest(path), target, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.Null(Assert.Single(target.Marks).Ttl);
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ImportAsync_UnexpiredMarker_KeepsTheLifetimeItHadLeft()
+    {
+        // Retention is the one thing that is per-store, so an expiring marker must arrive with the time it
+        // has left rather than being renewed to a full TTL or made permanent.
+        var path = NewFilePath();
+        try
+        {
+            var remaining = TimeSpan.FromHours(3);
+            WriteLines(path, Line("k1", DateTimeOffset.UtcNow + remaining));
+            var target = new RecordingStore();
+
+            var result = await CreateImporter().ImportAsync(new IdempotencyImportRequest(path), target, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            var ttl = Assert.Single(target.Marks).Ttl;
+            Assert.NotNull(ttl);
+            Assert.True((remaining - ttl!.Value).Duration() < TimeSpan.FromMinutes(1), $"ttl was {ttl}");
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ImportAsync_ExpiredMarkers_AreDroppedNotResurrected()
+    {
+        var path = NewFilePath();
+        try
+        {
+            WriteLines(path,
+                Line("expired", DateTimeOffset.UtcNow.AddMinutes(-1)),
+                Line("live"));
+            var target = new InMemoryIdempotencyStore();
+
+            var result = await CreateImporter().ImportAsync(new IdempotencyImportRequest(path), target, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(2, result.Value!.Keys);
+            Assert.Equal(1, result.Value.Imported);
+            Assert.Equal(1, result.Value.Expired);
+            Assert.False(await target.IsProcessedAsync("expired", CancellationToken.None));
+            Assert.True(await target.IsProcessedAsync("live", CancellationToken.None));
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ImportAsync_TornLine_IsSkippedAndCounted()
+    {
+        var path = NewFilePath();
+        try
+        {
+            WriteLines(path, Line("k1"), "{\"k\":\"k2\",\"e\":nu");
+            var target = new InMemoryIdempotencyStore();
+
+            var result = await CreateImporter().ImportAsync(new IdempotencyImportRequest(path), target, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(2, result.Value!.Lines);
+            Assert.Equal(1, result.Value.Keys);
+            Assert.Equal(1, result.Value.Imported);
+            Assert.Equal(1, result.Value.Unreadable);
+            Assert.True(await target.IsProcessedAsync("k1", CancellationToken.None));
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ImportAsync_RepeatedKey_IsWrittenOnceWithItsLastRecordedExpiry()
+    {
+        // The file is append-only, so a key re-marked after its TTL lapsed appears twice; the later line is
+        // the current truth, exactly as the file store resolves it when loading.
+        var path = NewFilePath();
+        try
+        {
+            WriteLines(path,
+                Line("k1", DateTimeOffset.UtcNow.AddMinutes(-1)),
+                Line("k1"));
+            var target = new RecordingStore();
+
+            var result = await CreateImporter().ImportAsync(new IdempotencyImportRequest(path), target, CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(2, result.Value!.Lines);
+            Assert.Equal(1, result.Value.Keys);
+            Assert.Equal(0, result.Value.Expired);
+            Assert.Null(Assert.Single(target.Marks).Ttl);
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ImportAsync_RunTwice_ReportsSecondPassAsAlreadyPresent()
+    {
+        var path = NewFilePath();
+        try
+        {
+            WriteLines(path, Line(RealKey));
+            var target = new InMemoryIdempotencyStore();
+            var importer = CreateImporter();
+
+            await importer.ImportAsync(new IdempotencyImportRequest(path), target, CancellationToken.None);
+            var second = await importer.ImportAsync(new IdempotencyImportRequest(path), target, CancellationToken.None);
+
+            Assert.True(second.IsSuccess);
+            Assert.Equal(0, second.Value!.Imported);
+            Assert.Equal(1, second.Value.AlreadyPresent);
+            Assert.Equal(0, second.Value.Failed);
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ImportAsync_StoreThatSwallowsWrites_ReportsFailedRatherThanAlreadyPresent()
+    {
+        // The stores fail open, so an outage returns false from TryMarkProcessedAsync just like an existing
+        // marker does. Reporting that as "already present" would make a lost migration look like a clean one.
+        var path = NewFilePath();
+        try
+        {
+            WriteLines(path, Line("k1"), Line("k2"));
+
+            var result = await CreateImporter().ImportAsync(
+                new IdempotencyImportRequest(path), new FailOpenStore(), CancellationToken.None);
+
+            Assert.True(result.IsSuccess);
+            Assert.Equal(0, result.Value!.Imported);
+            Assert.Equal(0, result.Value.AlreadyPresent);
+            Assert.Equal(2, result.Value.Failed);
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public async Task ImportAsync_MissingFile_Fails()
+    {
+        var result = await CreateImporter().ImportAsync(
+            new IdempotencyImportRequest(NewFilePath()), new InMemoryIdempotencyStore(), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("File.NotFound", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ImportAsync_EmptyPath_Fails()
+    {
+        var result = await CreateImporter().ImportAsync(
+            new IdempotencyImportRequest("  "), new InMemoryIdempotencyStore(), CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal("Validation.Invalid", result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ImportAsync_ThrowingStore_ReportsProgressWithTheFailure()
+    {
+        var path = NewFilePath();
+        try
+        {
+            WriteLines(path, Line("k1"), Line("k2"));
+
+            var result = await CreateImporter().ImportAsync(
+                new IdempotencyImportRequest(path), new ThrowingStore(failOnCall: 2), CancellationToken.None);
+
+            Assert.True(result.IsFailure);
+            Assert.Equal("Idempotency.ImportFailed", result.Error.Code);
+            Assert.Contains("after 1 marker(s)", result.Error.Message);
+        }
+        finally { Cleanup(path); }
+    }
+
+    private sealed class RecordingStore : IIdempotencyStore
+    {
+        public List<(string Key, TimeSpan? Ttl)> Marks { get; } = [];
+
+        public Task<bool> IsProcessedAsync(string key, CancellationToken ct)
+            => Task.FromResult(Marks.Any(m => m.Key == key));
+
+        public Task<bool> TryMarkProcessedAsync(string key, TimeSpan? ttl, CancellationToken ct)
+        {
+            Marks.Add((key, ttl));
+            return Task.FromResult(true);
+        }
+    }
+
+    /// <summary>Mimics a store outage under the fail-open contract: nothing is written, nothing throws.</summary>
+    private sealed class FailOpenStore : IIdempotencyStore
+    {
+        public Task<bool> IsProcessedAsync(string key, CancellationToken ct) => Task.FromResult(false);
+        public Task<bool> TryMarkProcessedAsync(string key, TimeSpan? ttl, CancellationToken ct) => Task.FromResult(false);
+    }
+
+    private sealed class ThrowingStore(int failOnCall) : IIdempotencyStore
+    {
+        private int _calls;
+
+        public Task<bool> IsProcessedAsync(string key, CancellationToken ct) => Task.FromResult(false);
+
+        public Task<bool> TryMarkProcessedAsync(string key, TimeSpan? ttl, CancellationToken ct)
+        {
+            if (++_calls >= failOnCall) throw new InvalidOperationException("store is down");
+            return Task.FromResult(true);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #39

Adds a one-off maintenance flag that carries idempotency markers from a file-backed store into whichever store the current configuration selects, so changing store does not mean re-downloading everything still present on the sources.

```
FileHorizon.Host.exe --import-idempotency /path/to/old/idempotency.jsonl [--dry-run]
```

## What it does

- Reads the JSONL file written by `FileBackedIdempotencyStore` and writes every marker through `IIdempotencyStore`, then exits without starting the pipeline — same shape as `--seed-idempotency`.
- Keys are store-agnostic already (`FileIdentity` derives them from source host, path, size and mtime), so nothing about the keys changes; the import only moves them.
- **Retention is per marker**: no expiry stays permanent, a future expiry is written with the time it had left, an already-expired entry is dropped rather than resurrected.
- **Fail-open stores are handled**: `RedisIdempotencyStore.TryMarkProcessedAsync` returns false during an outage, which is indistinguishable from "already present" — and for a migration that difference is the whole point. A marker reporting not-marked is verified with `IsProcessedAsync`; if it is genuinely absent it is counted as `FAILED` and the command exits 1, so a lost migration cannot read as a clean one. That second call only happens on the false path.
- Refuses the in-memory store (as seeding does, reusing its fallback diagnostics), and refuses the configured store's own file — that import reports every marker as already present, which reads as "nothing to do".
- Reports lines read, unique keys, imported, already known, dropped-expired, unreadable and failed, plus sample keys. `--dry-run` parses and reports without writing and does not require a durable store.

## Structure

- `IdempotencyFileReader` extracts the JSONL parsing (torn-line tolerance, last-write-wins on repeated keys) and is now used by both `FileBackedIdempotencyStore`'s load path and the importer, so a file cannot mean one thing to the store that wrote it and another to the import.
- `IdempotencyImporter` in the Application layer holds the logic and is unit-tested; `ImportIdempotencyCommand` is the thin host wrapper.
- Argument parsing (`CommandLineArgs`) and the unusable-store message (`IdempotencyStoreRequirement`) are now shared with `SeedIdempotencyCommand` rather than duplicated. The seed command's existing messages and exit codes are unchanged.
- `FileBackedIdempotencyStore` gains a `FilePath` property for the own-file guard.

## Compatibility

- No configuration changes, no behaviour change to the running pipeline. `--import-idempotency` and `--seed-idempotency` cannot be combined (exit 2); both still bypass the command-line configuration provider.
- The file-backed store's "loaded N marker(s)" log line now counts distinct keys rather than lines, since the reader de-duplicates. Same markers, slightly different number when a key was re-marked after its TTL lapsed.

## Testing

- 12 new tests in `IdempotencyImportTests` covering round-trip of a real marker written by the file store, dry run, permanent vs. remaining-lifetime TTL, dropped expiries, torn lines, repeated keys, re-import, fail-open store reported as failed, a throwing store reporting progress, and missing/empty paths.
- Full suite: 274 passed, 3 skipped.
- Smoke-tested end to end against a file-backed target store: dry run, import, re-import (all already known), plus every guard path — own file, missing file, missing value, both flags, and no durable store configured. A key containing spaces and `å ä ö` round-tripped intact.
- Not exercised against a live Redis in this change; the Redis path goes through the same `IIdempotencyStore` call the pipeline uses, and the fail-open verification is covered by a stub store.

## Docs

README gains a "Moving markers to another idempotency store" section next to the backlog-adoption one, including the caveat that Redis durability is weaker than a file on disk unless configured (persistent volume + AOF, and `noeviction` since markers have no TTL by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
